### PR TITLE
Fixed a Mongo bug when using forceExpire

### DIFF
--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -101,9 +101,11 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
     if (forceExpire) {
       where = { key };
       upsertData = {
-        key,
-        points,
-        expire: new Date(Date.now() + msDuration),
+        $set: {
+          key,
+          points,
+          expire: new Date(Date.now() + msDuration),
+        },
       };
     } else {
       where = {


### PR DESCRIPTION
When trying to use the blockDuration feature with Mongo, I stumbled into this error:

```
MongoError: the update operation document must contain atomic operators.
    at Function.create (/home/drye/dev/customer/node_modules/loopback-connector-mongodb/node_modules/mongodb-core/lib/error.js:43:12)
    at toError (/home/drye/dev/customer/node_modules/loopback-connector-mongodb/node_modules/mongodb/lib/utils.js:149:22)
    at checkForAtomicOperators (/home/drye/dev/customer/node_modules/loopback-connector-mongodb/node_modules/mongodb/lib/operations/collection_ops.js:161:12)
    at Collection.findOneAndUpdate (/home/drye/dev/customer/node_modules/loopback-connector-mongodb/node_modules/mongodb/lib/collection.js:1597:15)
    at Promise (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterMongo.js:129:24)
    at new Promise (<anonymous>)
    at RateLimiterMongo._upsert (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterMongo.js:128:12)
    at Promise (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterStoreAbstract.js:252:12)
    at new Promise (<anonymous>)
    at RateLimiterMongo._block (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterStoreAbstract.js:251:12)
    at RateLimiterMongo._afterConsume (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterStoreAbstract.js:61:14)
    at _upsert.then (/home/drye/dev/customer/node_modules/rate-limiter-flexible/lib/RateLimiterStoreAbstract.js:177:16)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
  driver: true,
  name: 'MongoError',
  [Symbol(mongoErrorContextSymbol)]: {} }
```

Turns out the `upsertData` was missing the `$set` operator. 