### PR TITLE
Fix RateLimiterUnion's consume TS response type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -99,7 +99,7 @@ export class RateLimiterMemcache extends RateLimiterStoreAbstract {
 export class RateLimiterUnion {
     constructor(...limiters: RateLimiterAbstract[]);
 
-    consume(key: string | number, points?: number): Promise<RateLimiterRes>[];
+    consume(key: string | number, points?: number): Promise<RateLimiterRes[]>;
 }
 
 export class RLWrapperBlackAndWhite extends RateLimiterAbstract {


### PR DESCRIPTION
When consume returns it contains a single promise with an array of results. The previous type signature said it returned an array of promises.