### PR TITLE
Add type signatures for toString and toJSON methods of RateLimiterRes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,13 @@ export interface RateLimiterRes {
     readonly remainingPoints: number;
     readonly consumedPoints: number;
     readonly isFirstInDuration: boolean;
+    toString(): string;
+    toJSON(): {
+        remainingPoints: number;
+        msBeforeNext: number;
+        consumedPoints: number;
+        isFirstInDuration: boolean;
+    };
 }
 
 export class RateLimiterAbstract {


### PR DESCRIPTION
This PR adds type signatures for the `toJSON` and `toString` methods of `RateLimiterRes`. I have deliberately kept the same order for `toJSON` as specified in `_getDecoratedProperties` and I have not made any properties of `toJSON` readonly, because I don't think it would be appropriate to make a JSON response non-immutable (although perhaps you could argue this).