### PR TITLE
Corrects an issue where _query expects an object but a string is pas…

### DIFF
--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -120,7 +120,9 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
    */
   _createTable() {
     return new Promise((resolve, reject) => {
-      this._query(this._getCreateTableStmt())
+      this._query({
+        text: this._getCreateTableStmt(),
+      })
         .then(() => {
           resolve();
         })


### PR DESCRIPTION
…sed and initialization was not truly creating the database table. Tested with both a PG pool and Sequelize instance on another project. Both failed until this was changed.