### PR TITLE
Use collection from mongoose client

### DIFF
--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -78,7 +78,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
   _initCollection() {
     const db = typeof this.client.db === 'function'
       ? this.client.db(this.dbName)
-      : this.client.db;
+      : this.client;
 
     const collection = db.collection(this.tableName);
     collection.createIndex({ expire: -1 }, { expireAfterSeconds: 0 });

--- a/test/RateLimiterMongo.test.js
+++ b/test/RateLimiterMongo.test.js
@@ -310,6 +310,20 @@ describe('RateLimiterMongo with fixed window', function () {
     mongoClientStub = sinon.stub(mongoClient, 'db').callsFake(() => mongoDb);
   });
 
+  it('use collection from client instead of db if Mongoose in use', () => {
+    const createIndex = sinon.spy();
+    const mongooseConnection = {
+      collection: () => ({
+        createIndex,
+      }),
+    };
+
+    new RateLimiterMongo({
+      storeClient: mongooseConnection,
+    });
+    expect(createIndex.called);
+  })
+
   it('delete key and return true', (done) => {
     const testKey = 'deletetrue';
     sinon.stub(mongoCollection, 'deleteOne').callsFake(() => {


### PR DESCRIPTION
When mongoose is used with command buffering collection should be asked from client because db might not be available before connection is established.

resolves #26 