### PR TITLE
Add IRateLimiterResOptions interface and RateLimiterRes class

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const RateLimiterMemcache = require('./lib/RateLimiterMemcache');
 const RLWrapperBlackAndWhite = require('./lib/RLWrapperBlackAndWhite');
 const RateLimiterUnion = require('./lib/RateLimiterUnion');
 const RateLimiterQueue = require('./lib/RateLimiterQueue');
+const RateLimiterRes = require('./lib/RateLimiterRes');
 
 module.exports = {
   RateLimiterRedis,
@@ -22,4 +23,5 @@ module.exports = {
   RLWrapperBlackAndWhite,
   RateLimiterUnion,
   RateLimiterQueue,
+  RateLimiterRes,
 };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,18 @@
-export interface RateLimiterRes {
+export interface IRateLimiterResOptions {
+    msBeforeNext?: number;
+    remainingPoints?: number;
+    consumedPoints?: number;
+    isFirstInDuration?: boolean;
+}
+
+export class RateLimiterRes {
+    constructor(opts: IRateLimiterResOptions);
+
     readonly msBeforeNext: number;
     readonly remainingPoints: number;
     readonly consumedPoints: number;
     readonly isFirstInDuration: boolean;
+    
     toString(): string;
     toJSON(): {
         remainingPoints: number;


### PR DESCRIPTION
This allows using

```
if (rlRejected instanceof RateLimiterRes) {
    res.set('Retry-After', String(Math.round(rlRejected.msBeforeNext / 1000)) || 1);
    res.status(429).send('Too Many Requests');
} else {
    throw rlRejected;
}
```

instead of 

```
if (rlRejected instanceof Error) {
    throw rlRejected;
} else {
    res.set('Retry-After', String(Math.round(rlRejected.msBeforeNext / 1000)) || 1);
    res.status(429).send('Too Many Requests');
}
```

As just comparing instanceof Error is not accurate (see all possible classes https://nodejs.org/api/errors.html)
it's better to check if the rlRejected is instanceof RateLimiterRes and if it's not then throw the error.