### PR TITLE
Fix typing for rateLimiterInstance.get()

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -33,7 +33,7 @@ export class RateLimiterAbstract {
 
     block(key: string | number, secDuration: number, options?: {[key: string]: any }): Promise<RateLimiterRes>;
 
-    get(key: string | number, options?: {[key: string]: any }): Promise<RateLimiterRes>|null;
+    get(key: string | number, options?: {[key: string]: any }): Promise<RateLimiterRes|null>;
 
     delete(key: string | number, options?: {[key: string]: any }): Promise<boolean>;
 
@@ -122,7 +122,7 @@ export class RateLimiterMongo extends RateLimiterStoreAbstract {
 
     block(key: string | number, secDuration: number, options?: IRateLimiterMongoFunctionOptions): Promise<RateLimiterRes>;
 
-    get(key: string | number, options?: IRateLimiterMongoFunctionOptions): Promise<RateLimiterRes>|null;
+    get(key: string | number, options?: IRateLimiterMongoFunctionOptions): Promise<RateLimiterRes|null>;
 
     delete(key: string | number, options?: IRateLimiterMongoFunctionOptions): Promise<boolean>;
 }


### PR DESCRIPTION
Typing is currently incorrect for `rateLimiterInstance.get()`: it currently returns `Promise<RateLimiterRes> | null`, which breaks `Promise.all` typing (which always expects a Promise – even if it doesn't necessarily require one.. a different story).

In any case, the reality is that `.get()` should _always_ return a `Promise` anyway, so moving the possibility of `null` inside the promise result fixes both issues.