### PR TITLE
Make BurstRateLimiter compatible with RateLimiterQueue

### DIFF
--- a/lib/BurstyRateLimiter.js
+++ b/lib/BurstyRateLimiter.js
@@ -3,28 +3,71 @@ const RateLimiterRes = require("./RateLimiterRes");
 module.exports = class BurstyRateLimiter {
   constructor(rateLimiter, burstLimiter) {
     this._rateLimiter = rateLimiter;
-    this._burstLimiter = burstLimiter
+    this._burstLimiter = burstLimiter;
+    this.points = this._rateLimiter.points + this._burstLimiter.points;
   }
 
   consume(key, pointsToConsume = 1, options = {}) {
-    return this._rateLimiter.consume(key, pointsToConsume, options)
+    return this._rateLimiter
+      .consume(key, pointsToConsume, options)
+      .then((rlRes) => {
+        return this._burstLimiter.get(key).then((blRes) => {
+          return this._combineRes(rlRes, blRes);
+        });
+      })
       .catch((rlRej) => {
         if (rlRej instanceof RateLimiterRes) {
-          return this._burstLimiter.consume(key, pointsToConsume, options)
-            .then(() => {
-              return Promise.resolve(rlRej)
+          return this._burstLimiter
+            .consume(key, pointsToConsume, options)
+            .then((blRes) => {
+              return this._combineRes(rlRej, blRes);
             })
             .catch((blRej) => {
-                if (blRej instanceof RateLimiterRes) {
-                  return Promise.reject(rlRej)
-                } else {
-                  return Promise.reject(blRej)
-                }
+              if (blRej instanceof RateLimiterRes) {
+                return Promise.reject(this._combineRes(rlRej, blRej));
+              } else {
+                return Promise.reject(blRej);
               }
-            )
+            });
         } else {
-          return Promise.reject(rlRej)
+          return Promise.reject(rlRej);
         }
-      })
+      });
+  }
+
+  get(key) {
+    return Promise.all([
+      this._rateLimiter.get(key),
+      this._burstLimiter.get(key),
+    ]).then(([rlRes, blRes]) => {
+      return this._combineRes(rlRes, blRes);
+    });
+  }
+
+  /**
+   * Combine both rate limiter responses object into one.
+   */
+  _combineRes(rlRes, blRes) {
+    const combinedRes = {
+      remainingPoints:
+        (rlRes ? rlRes.remainingPoints : this._rateLimiter.points) +
+        (blRes ? blRes.remainingPoints : this._burstLimiter.points),
+      msBeforeNext: Math.min(
+        rlRes != null ? rlRes.msBeforeNext : this._rateLimiter.duration,
+        blRes != null ? blRes.msBeforeNext : this._burstLimiter.duration
+      ),
+      consumedPoints: Math.min(
+        (rlRes ? rlRes.consumedPoints : 0) + (blRes ? blRes.consumedPoints : 0),
+        this._rateLimiter.points + this._burstLimiter.points
+      ),
+      isFirstInDuration: Boolean(
+        rlRes && blRes
+          ? rlRes.isFirstInDuration && blRes.isFirstInDuration
+          : (rlRes && rlRes.isFirstInDuration) ||
+              (blRes && blRes.isFirstInDuration)
+      ),
+    };
+
+    return combinedRes;
   }
 };

--- a/lib/BurstyRateLimiter.js
+++ b/lib/BurstyRateLimiter.js
@@ -44,9 +44,12 @@ module.exports = class BurstyRateLimiter {
     });
   }
 
-  /**
-   * Combine both rate limiter responses object into one.
-   */
+   /**
+    * Merge rate limiter response objects. Responses can be null
+    *
+    * @param {RateLimiterRes} [rlRes] Rate limiter response
+    * @param {RateLimiterRes} [blRes] Bursty limiter response
+    */
   _combineRes(rlRes, blRes) {
     const combinedRes = {
       remainingPoints:
@@ -56,10 +59,7 @@ module.exports = class BurstyRateLimiter {
         rlRes != null ? rlRes.msBeforeNext : this._rateLimiter.duration,
         blRes != null ? blRes.msBeforeNext : this._burstLimiter.duration
       ),
-      consumedPoints: Math.min(
-        (rlRes ? rlRes.consumedPoints : 0) + (blRes ? blRes.consumedPoints : 0),
-        this._rateLimiter.points + this._burstLimiter.points
-      ),
+      consumedPoints: (rlRes ? rlRes.consumedPoints : 0) + (blRes ? blRes.consumedPoints : 0),
       isFirstInDuration: Boolean(
         rlRes && blRes
           ? rlRes.isFirstInDuration && blRes.isFirstInDuration

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -157,7 +157,7 @@ interface IRateLimiterQueueOpts {
 }
 
 export class RateLimiterQueue {
-    constructor(limiterFlexible: RateLimiterAbstract, opts?: IRateLimiterQueueOpts)
+    constructor(limiterFlexible: RateLimiterAbstract | BurstyRateLimiter, opts?: IRateLimiterQueueOpts)
 }
 
 export class BurstyRateLimiter {

--- a/test/BurstyRateLimiter.test.js
+++ b/test/BurstyRateLimiter.test.js
@@ -7,7 +7,7 @@ const RateLimiterRedis = require('../lib/RateLimiterRedis');
 const redisMock = require('redis-mock');
 const { redisEvalMock, getRedisClientClosed } = require('./helper');
 
-describe('BurstyRateLimiter', () => {
+describe.only('BurstyRateLimiter', () => {
   it('consume 1 point from limiter', (done) => {
     const testKey = 'consume1';
     const rlMemory = new RateLimiterMemory({ points: 1, duration: 1 });
@@ -16,7 +16,7 @@ describe('BurstyRateLimiter', () => {
     bursty.consume(testKey)
       .then((res) => {
         expect(res.consumedPoints).to.equal(1);
-        expect(res.remainingPoints).to.equal(0);
+        expect(res.remainingPoints).to.equal(1);
         expect(res.msBeforeNext <= 1000).to.equal(true);
         expect(res.isFirstInDuration).to.equal(true);
         done();
@@ -31,6 +31,7 @@ describe('BurstyRateLimiter', () => {
     const rlMemory = new RateLimiterMemory({ points: 1, duration: 1 });
     const blMemory = new RateLimiterMemory({ points: 1, duration: 10 });
     const bursty = new BurstyRateLimiter(rlMemory, blMemory);
+
     bursty.consume(testKey)
       .then(() => {
         bursty.consume(testKey)
@@ -64,7 +65,7 @@ describe('BurstyRateLimiter', () => {
                 done(new Error('must not'));
               })
               .catch((rej) => {
-                expect(rej.consumedPoints).to.equal(3);
+                expect(rej.consumedPoints).to.equal(2);
                 expect(rej.remainingPoints).to.equal(0);
                 expect(rej.msBeforeNext <= 1000).to.equal(true);
                 expect(rej.isFirstInDuration).to.equal(false);
@@ -124,25 +125,39 @@ describe('BurstyRateLimiter', () => {
       keyPrefix: 'bursty',
     });
     const bursty = new BurstyRateLimiter(rlRedis, blRedisClosed);
-    bursty.consume(testKey)
+    bursty
+      .consume(testKey)
       .then(() => {
-        bursty.consume(testKey)
-          .then(() => {
-            done(new Error('must not'));
-          })
-          .catch((err) => {
-            expect(err instanceof Error).to.equal(true);
-            rlRedis.get(testKey)
-              .then((rlRes) => {
-                expect(rlRes.consumedPoints).to.equal(2);
-                expect(rlRes.remainingPoints).to.equal(0);
-                expect(rlRes.msBeforeNext <= 1000).to.equal(true);
-                done();
-              });
-          });
+        done(new Error('must not'));
       })
       .catch((err) => {
-        done(err);
-      });
+        expect(err instanceof Error).to.equal(true);
+        rlRedis.get(testKey).then((rlRes) => {
+          expect(rlRes.consumedPoints).to.equal(1);
+          expect(rlRes.remainingPoints).to.equal(0);
+          expect(rlRes.msBeforeNext <= 1000).to.equal(true);
+          done();
+        })
+        .catch(err => done(err));
+      })
   });
+
+  it('get returns the combined RateLimiterRes of both limiters', (done) => {
+    const rlMemory = new RateLimiterMemory({ points: 10, duration: 1 });
+    const rlBurstMemory = new RateLimiterMemory({ points: 20, duration: 1 });
+
+    const bl = new BurstyRateLimiter(rlMemory, rlBurstMemory);
+
+    bl.consume('keyA', 5)
+    .then((res) => {
+      expect(res.consumedPoints).to.equal(5);
+      expect(res.remainingPoints).to.equal(25);
+      expect(res.msBeforeNext <= 1000).to.equal(true);
+      expect(res.isFirstInDuration).to.equal(true);
+      done();
+    })
+    .catch((err) => {
+      done(err);
+    });
+  })
 });

--- a/test/BurstyRateLimiter.test.js
+++ b/test/BurstyRateLimiter.test.js
@@ -7,7 +7,7 @@ const RateLimiterRedis = require('../lib/RateLimiterRedis');
 const redisMock = require('redis-mock');
 const { redisEvalMock, getRedisClientClosed } = require('./helper');
 
-describe.only('BurstyRateLimiter', () => {
+describe('BurstyRateLimiter', () => {
   it('consume 1 point from limiter', (done) => {
     const testKey = 'consume1';
     const rlMemory = new RateLimiterMemory({ points: 1, duration: 1 });
@@ -36,7 +36,7 @@ describe.only('BurstyRateLimiter', () => {
       .then(() => {
         bursty.consume(testKey)
           .then((res) => {
-            expect(res.consumedPoints).to.equal(2);
+            expect(res.consumedPoints).to.equal(3);
             expect(res.remainingPoints).to.equal(0);
             expect(res.msBeforeNext <= 1000).to.equal(true);
             expect(res.isFirstInDuration).to.equal(false);
@@ -65,7 +65,7 @@ describe.only('BurstyRateLimiter', () => {
                 done(new Error('must not'));
               })
               .catch((rej) => {
-                expect(rej.consumedPoints).to.equal(2);
+                expect(rej.consumedPoints).to.equal(5);
                 expect(rej.remainingPoints).to.equal(0);
                 expect(rej.msBeforeNext <= 1000).to.equal(true);
                 expect(rej.isFirstInDuration).to.equal(false);


### PR DESCRIPTION
Add `BurstRateLimiter.get(key)` method and update typescript definitions.

Also I'm not sure if it's a bug or expected behaviour, but I noticed that the consumed points of the memory limiter is incremented by 1 even when the point can't be consumed. This causes the consumed points to be greater than the total available points. As a result, I made sure that the this limiter's get method will never have consumed points greater than the total available points. For example, in this test, why are 3 points consumed instead of 2: https://github.com/animir/node-rate-limiter-flexible/pull/69/files#diff-d34378bd170b6ff95ace3c0d1ae6b923L67.

See #66.