### PR TITLE
fix(Types definitions): add RateLimiterQueue missing methods

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -157,7 +157,11 @@ interface IRateLimiterQueueOpts {
 }
 
 export class RateLimiterQueue {
-    constructor(limiterFlexible: RateLimiterAbstract, opts?: IRateLimiterQueueOpts)
+    constructor(limiterFlexible: RateLimiterAbstract, opts?: IRateLimiterQueueOpts);
+
+    getTokensRemaining(key?: string | number): Promise<RateLimiterRes>;
+
+    removeTokens(tokens: number, key?: string | number): Promise<RateLimiterRes>;
 }
 
 export class BurstyRateLimiter {


### PR DESCRIPTION
https://github.com/animir/node-rate-limiter-flexible/commit/2a954d3a12bc4ad2d410166f914903bd250f5fb2#diff-0e3ac3694919aca1db302bc3ebe669f2 introduced type definition for the `RateLimiterQueue` class, but its definition was partial. Therefore, Typescript compiler was issuing errors (and did not get type hints) while using this class.