### PR TITLE
Set correct clientType for node-postgres@8.0.0 BoundPool class

### DIFF
--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -152,17 +152,23 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
   }
 
   set clientType(value) {
+    const constructorName = this.client.constructor.name;
+
     if (typeof value === 'undefined') {
-      if (this.client.constructor.name === 'Client') {
+      if (constructorName === 'Client') {
         value = 'client';
-      } else if (this.client.constructor.name === 'Pool') {
+      } else if (
+        constructorName === 'Pool' ||
+        constructorName === 'BoundPool'
+      ) {
         value = 'pool';
-      } else if (this.client.constructor.name === 'Sequelize') {
+      } else if (constructorName === 'Sequelize') {
         value = 'sequelize';
       } else {
         throw new Error('storeType is not defined');
       }
     }
+
     this._clientType = value.toLowerCase();
   }
 


### PR DESCRIPTION
Since node-postgres@8.0.0, the pool factory returns a `BoundPool` class instead of the `Pool` class. This resulted in the store type exception being thrown when not explicitly setting a value for `clientType`.

See:
https://github.com/brianc/node-postgres/blame/ea6ac2ad2313af57159b10a0292c0c178e8e0923/packages/pg/lib/index.js#L16