### PR TITLE
unref() should be guarded so it can work on client

### DIFF
--- a/lib/component/MemoryStorage/MemoryStorage.js
+++ b/lib/component/MemoryStorage/MemoryStorage.js
@@ -42,7 +42,9 @@ module.exports = class MemoryStorage {
       this._storage[key].timeoutId = setTimeout(() => {
         delete this._storage[key];
       }, durationMs);
-      this._storage[key].timeoutId.unref();
+      if (this._storage[key].timeoutId.unref) {
+        this._storage[key].timeoutId.unref();
+      }
     }
 
     return new RateLimiterRes(0, durationMs === 0 ? -1 : durationMs, this._storage[key].value, true);

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Node.js rate limiter by key and protection from DDoS and Brute-Force attacks in process Memory, Redis, MongoDb, Memcached, MySQL, PostgreSQL, Cluster or PM",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/istanbul/lib/cli.js cover ./node_modules/.bin/_mocha --recursive",
+    "test": "istanbul -v cover -- _mocha --recursive",
     "debug-test": "mocha --inspect-brk lib/**/**.test.js",
-    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
-    "eslint": "node_modules/eslint/bin/eslint.js --quiet lib/**/**.js test/**/**.js",
-    "eslint-fix": "node_modules/eslint/bin/eslint.js --fix lib/**/**.js test/**/**.js"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "eslint": "eslint --quiet lib/**/**.js test/**/**.js",
+    "eslint-fix": "eslint --fix lib/**/**.js test/**/**.js"
   },
   "repository": {
     "type": "git",

--- a/test/component/MemoryStorage/MemoryStorage.test.js
+++ b/test/component/MemoryStorage/MemoryStorage.test.js
@@ -49,4 +49,23 @@ describe('MemoryStorage', function MemoryStorageTest() {
   it('return false, if there is no record to delete', () => {
     expect(storage.delete(testKey)).to.equal(false);
   });
+
+  it('should not fail in the absence of Timeout::unref', (done) => {
+    // Node (where we most likely be running tests) provides `Timeout.prototype.unref`, however
+    // MemoryStorage should run in environments where `Timeout.prototype.unref` is not provided
+    // (e.g. browsers). For this test we remove `unref` from `Timeout.prototype` only for the
+    // duration of this test, to verify that MemoryStorage.prototype.set won't throw.
+    const handle = setTimeout(() => {}, 0);
+    const isHandleObject = typeof handle === 'object' && !!handle.constructor;
+    let timeoutUnref;
+    if (isHandleObject) {
+      timeoutUnref = handle.constructor.prototype.unref;
+      delete handle.constructor.prototype.unref;
+    }
+    expect(() => new MemoryStorage().set('key', 0, 0.001)).to.not.throw();
+    setTimeout(done, 250);
+    if (isHandleObject) {
+      handle.constructor.prototype.unref = timeoutUnref;
+    }
+  });
 });


### PR DESCRIPTION
I wanted to try getting a memory rate limiter working in the browser. Unfortunately, `MemoryStorage` tries to call `unref()` on the result of `setTimeout`, which is a node-ism. By guarding this call, the code works in a browser. What do you think?