### PR TITLE
Add typeorm support for postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It works with _Redis_, process _Memory_, _Cluster_ or _PM2_, _Memcached_, _Mongo
 
 **Ready for growth.** It provides unified API for all limiters. Whenever your application grows, it is ready. Prepare your limiters in minutes.
 
-**Friendly.** No matter which node package you prefer: `redis` or `ioredis`, `sequelize` or `knex`, `memcached`, native driver or `mongoose`. It works with all of them.
+**Friendly.** No matter which node package you prefer: `redis` or `ioredis`, `sequelize`/`typeorm` or `knex`, `memcached`, native driver or `mongoose`. It works with all of them.
 
 **In memory blocks.** Avoid extra requests to store with [inmemoryBlockOnConsumed](https://github.com/animir/node-rate-limiter-flexible/wiki/Options#inmemoryblockonconsumed).
 
@@ -122,7 +122,7 @@ Some copy/paste examples on Wiki:
 * [RateLimiterMemcache](https://github.com/animir/node-rate-limiter-flexible/wiki/Memcache)
 * [RateLimiterMongo](https://github.com/animir/node-rate-limiter-flexible/wiki/Mongo) (with [sharding support](https://github.com/animir/node-rate-limiter-flexible/wiki/Mongo#mongodb-sharding-options))
 * [RateLimiterMySQL](https://github.com/animir/node-rate-limiter-flexible/wiki/MySQL) (support Sequelize and Knex)
-* [RateLimiterPostgres](https://github.com/animir/node-rate-limiter-flexible/wiki/PostgreSQL) (support Sequelize and Knex)
+* [RateLimiterPostgres](https://github.com/animir/node-rate-limiter-flexible/wiki/PostgreSQL) (support Sequelize, TypeORM and Knex)
 * [RateLimiterCluster](https://github.com/animir/node-rate-limiter-flexible/wiki/Cluster) ([PM2 cluster docs read here](https://github.com/animir/node-rate-limiter-flexible/wiki/PM2-cluster))
 * [RateLimiterMemory](https://github.com/animir/node-rate-limiter-flexible/wiki/Memory)
 * [RateLimiterUnion](https://github.com/animir/node-rate-limiter-flexible/wiki/RateLimiterUnion) Combine 2 or more limiters to act as single

--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -150,7 +150,6 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
   }
 
   _getCreateTableStmt() {
-    
     return `CREATE TABLE IF NOT EXISTS ${this.tableName} ( 
       key varchar(255) PRIMARY KEY,
       points integer NOT NULL DEFAULT 0,

--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -102,7 +102,7 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
       case 'knex':
         return this.client.client.acquireConnection();
       case 'typeorm':
-        return this.client.driver.master;
+        return Promise.resolve(this.client.driver.master);
       default:
         return Promise.resolve(this.client);
     }
@@ -150,6 +150,7 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
   }
 
   _getCreateTableStmt() {
+    
     return `CREATE TABLE IF NOT EXISTS ${this.tableName} ( 
       key varchar(255) PRIMARY KEY,
       points integer NOT NULL DEFAULT 0,

--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -101,6 +101,8 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
         return this.client.connectionManager.getConnection();
       case 'knex':
         return this.client.client.acquireConnection();
+      case 'typeorm':
+        return this.client.driver.master;
       default:
         return Promise.resolve(this.client);
     }
@@ -114,6 +116,8 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
         return this.client.connectionManager.releaseConnection(conn);
       case 'knex':
         return this.client.client.releaseConnection(conn);
+      case 'typeorm':
+        return true;
       default:
         return true;
     }

--- a/test/RateLimiterPostgres.test.js
+++ b/test/RateLimiterPostgres.test.js
@@ -453,6 +453,28 @@ describe('RateLimiterPostgres with fixed window', function RateLimiterPostgresTe
     });
   });
 
+  it('private _getConnection returns client for TypeORM', (done) => {
+    class Pool {
+      Pool() {}
+      query() {}
+    }
+
+    const typeORMConnection = {
+      driver: { master: new Pool()}
+    }
+
+    const rateLimiter = new RateLimiterPostgres({
+      storeClient: typeORMConnection,
+      storeType: 'typeorm',
+    }, () => {
+      rateLimiter._getConnection()
+        .then((conn) => {
+          expect(conn).to.equal(typeORMConnection.driver.master);
+          done();
+        });
+    });
+  });
+
   it('Pool does not require specific connection releasing', (done) => {
     class Pool {
       Pool() {}
@@ -504,6 +526,25 @@ describe('RateLimiterPostgres with fixed window', function RateLimiterPostgresTe
       storeType: 'knex',
     }, () => {
       expect(rateLimiter._releaseConnection()).to.equal(321);
+      done();
+    });
+  });
+
+  it('TypeORM does not require specific connection releasing', (done) => {
+    class Pool {
+      Pool() {}
+      query() {}
+    }
+
+    const typeORMConnection = {
+      driver: { master: new Pool()}
+    }
+
+    const rateLimiter = new RateLimiterPostgres({
+      storeClient: typeORMConnection,
+      storeType: 'typeorm',
+    }, () => {
+      expect(rateLimiter._releaseConnection()).to.equal(true);
       done();
     });
   });


### PR DESCRIPTION
Implements #96 

# Description

Adds support for postgres with typeorm
Have this working in a project but was doing this little work outside and passing the pg pool instance instead.


# Usage

````js
const connection = await createConnection({...});
const options = {
    storeClient: connection,
    storeType: 'typeorm',
    ...
  }
const rateLimiter = new RateLimiterPostgres(opts)
````

# Additional notes
I think same implementation should work for MySQL also. Can't test it now. Can add it later. 
Hope it works 🤞 