### PR TITLE
Replace deprecated MongoDB option

### DIFF
--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -46,9 +46,11 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
         .then((conn) => {
           this.client = conn;
           this._initCollection();
+          this._driverVersion = getDriverVersion(this.client);
         });
     } else {
       this._initCollection();
+      this._driverVersion = getDriverVersion(this.client);
     }
   }
 
@@ -101,8 +103,6 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
     collection.createIndex(Object.assign({}, this.indexKeyPrefix, { key: 1 }), { unique: true });
 
     this._collection = collection;
-
-    this._driverVersion = getDriverVersion(this.client);
   }
 
   _getRateLimiterRes(rlKey, changedPoints, result) {

--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -1,15 +1,14 @@
-const path = require('path');
 const RateLimiterStoreAbstract = require('./RateLimiterStoreAbstract');
 const RateLimiterRes = require('./RateLimiterRes');
 
 /**
  * Get MongoDB driver version as upsert options differ
+ * @params {Object} Client instance
  * @returns {Number|undefined} Major version
  */
-function getDriverVersion() {
+function getDriverVersion(client) {
   try {
-    const configPath = path.resolve(path.dirname(require.resolve('mongodb')), 'package.json');
-    const { version } = require(configPath); // eslint-disable-line global-require,import/no-dynamic-require
+    const { version } = client.topology.s.options.metadata.driver;
     const majorVersion = parseInt(version);
 
     return majorVersion;
@@ -102,6 +101,8 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
     collection.createIndex(Object.assign({}, this.indexKeyPrefix, { key: 1 }), { unique: true });
 
     this._collection = collection;
+
+    this._driverVersion = getDriverVersion(this.client);
   }
 
   _getRateLimiterRes(rlKey, changedPoints, result) {
@@ -172,8 +173,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
     const upsertOptions = {
       upsert: true,
     };
-    const driverVersion = getDriverVersion();
-    if (driverVersion >= 4) {
+    if (this._driverVersion >= 4) {
       upsertOptions.returnDocument = 'after';
     } else {
       upsertOptions.returnOriginal = false;

--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -163,7 +163,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
         upsertData,
         {
           upsert: true,
-          returnOriginal: false,
+          returnDocument: 'after',
         } // eslint-disable-line comma-dangle
       ).then((res) => {
         resolve(res);
@@ -188,7 +188,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
             replaceTo,
             {
               upsert: true,
-              returnOriginal: false,
+              returnDocument: 'after',
             } // eslint-disable-line comma-dangle
           ).then((res) => {
             resolve(res);

--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -257,7 +257,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
     const where = Object.assign({ key: rlKey }, docAttrs);
 
     return this._collection.deleteOne(where)
-      .then(res => res.result.n > 0);
+      .then(res => res.deletedCount > 0);
   }
 }
 

--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -1,5 +1,22 @@
+const path = require('path');
 const RateLimiterStoreAbstract = require('./RateLimiterStoreAbstract');
 const RateLimiterRes = require('./RateLimiterRes');
+
+/**
+ * Get MongoDB driver version as upsert options differ
+ * @returns {Number|undefined} Major version
+ */
+function getDriverVersion() {
+  try {
+    const configPath = path.resolve(path.dirname(require.resolve('mongodb')), 'package.json');
+    const { version } = require(configPath); // eslint-disable-line global-require,import/no-dynamic-require
+    const majorVersion = parseInt(version);
+
+    return majorVersion;
+  } catch (err) {
+    return undefined;
+  }
+}
 
 class RateLimiterMongo extends RateLimiterStoreAbstract {
   /**
@@ -151,6 +168,17 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
       upsertData.$setOnInsert = Object.assign(upsertData.$setOnInsert, docAttrs);
     }
 
+    // Options for collection updates differ between driver versions
+    const upsertOptions = {
+      upsert: true,
+    };
+    const driverVersion = getDriverVersion();
+    if (driverVersion >= 4) {
+      upsertOptions.returnDocument = 'after';
+    } else {
+      upsertOptions.returnOriginal = false;
+    }
+
     /*
      * 1. Find actual limit and increment points
      * 2. If limit expired, but Mongo doesn't clean doc by TTL yet, try to replace limit doc completely
@@ -161,10 +189,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
       this._collection.findOneAndUpdate(
         where,
         upsertData,
-        {
-          upsert: true,
-          returnDocument: 'after',
-        } // eslint-disable-line comma-dangle
+        upsertOptions,
       ).then((res) => {
         resolve(res);
       }).catch((errUpsert) => {
@@ -186,10 +211,7 @@ class RateLimiterMongo extends RateLimiterStoreAbstract {
           this._collection.replaceOne(
             replaceWhere,
             replaceTo,
-            {
-              upsert: true,
-              returnDocument: 'after',
-            } // eslint-disable-line comma-dangle
+            upsertOptions,
           ).then((res) => {
             resolve(res);
           }).catch((errReplace) => {

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "istanbul": "^0.4.5",
     "memcached-mock": "^0.1.0",
     "mocha": "^5.1.1",
-    "mongodb": "^3.6.9",
-    "mongodb-4": "npm:mongodb@4.0.0-beta.5",
     "redis-mock": "^0.48.0",
     "sinon": "^5.0.10"
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "istanbul": "^0.4.5",
     "memcached-mock": "^0.1.0",
     "mocha": "^5.1.1",
+    "mongodb": "^3.6.9",
+    "mongodb-4": "npm:mongodb@4.0.0-beta.5",
     "redis-mock": "^0.48.0",
     "sinon": "^5.0.10"
   }

--- a/test/RateLimiterMongo.test.js
+++ b/test/RateLimiterMongo.test.js
@@ -42,7 +42,7 @@ describe('RateLimiterMongo with fixed window', function RateLimiterMongoTest() {
     try {
       new RateLimiterMongo({ points: 2, duration: 5 });
     } catch (err) {
-      done()
+      done();
     }
   });
 
@@ -335,9 +335,7 @@ describe('RateLimiterMongo with fixed window', function RateLimiterMongoTest() {
   it('delete key and return true', (done) => {
     const testKey = 'deletetrue';
     sinon.stub(mongoCollection, 'deleteOne').callsFake(() => Promise.resolve({
-      result: {
-        n: 1,
-      },
+      deletedCount: 1,
     }));
 
     const rateLimiter = new RateLimiterMongo({


### PR DESCRIPTION
The `returnOriginal` option for `findOneAndUpdate` is deprecated, see https://github.com/mongodb/node-mongodb-native/blob/f916843ad2002a4c829c5f126e58e8efba257525/lib/collection.js#L1720

This should get rid of warnings like `[MONGODB DRIVER] DeprecationWarning: collection.findOneAndUpdate option [returnOriginal] is deprecated and will be removed in a later version.`