### PR TITLE
chore(package.json): add files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "git+https://github.com/animir/node-rate-limiter-flexible.git"
   },
+  "files": [
+    "index.js"
+  ],
   "keywords": [
     "authorization",
     "security",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "url": "git+https://github.com/animir/node-rate-limiter-flexible.git"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "lib"
   ],
   "keywords": [
     "authorization",


### PR DESCRIPTION
Hello,

NPM is publishing all the thing present on this repo, so the disk size is bigger than the necessary

<img width="1329" alt="Screen Shot 2021-06-23 at 01 35 23" src="https://user-images.githubusercontent.com/2096101/123012844-48e54300-d3c3-11eb-8e7e-1dd12a4dd267.png">

After the change, the next npm release is going to publish only the necessary stuff 🙂
