### PR TITLE
Allow cleanup in memory data

### DIFF
--- a/lib/RateLimiterStoreAbstract.js
+++ b/lib/RateLimiterStoreAbstract.js
@@ -284,6 +284,7 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterAbstract {
     return new Promise((resolve, reject) => {
       this._delete(rlKey, options)
         .then((res) => {
+          this._inmemoryBlockedKeys.delete(key);
           resolve(res);
         })
         .catch((err) => {
@@ -294,11 +295,9 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterAbstract {
 
   /**
    * Cleanup keys no-matter expired or not.
-   * 
-   * @param {string|undefined} key
    */
-  cleanupInmemory(key) {
-    this._inmemoryBlockedKeys.cleanup(key);
+  deleteInMemory() {
+    this._inmemoryBlockedKeys.delete();
   }
 
   /**

--- a/lib/RateLimiterStoreAbstract.js
+++ b/lib/RateLimiterStoreAbstract.js
@@ -364,4 +364,21 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterAbstract {
   _delete(rlKey, options = {}) { // eslint-disable-line no-unused-vars
     throw new Error("You have to implement the method '_delete'!");
   }
+
+  /**
+   * Have to be implemented
+   * Resolve with object used for {@link _getRateLimiterRes} to generate {@link RateLimiterRes}
+   *
+   * @param {string} rlKey
+   * @param {number} points
+   * @param {number} msDuration
+   * @param {boolean} forceExpire
+   * @param {Object} options
+   * @abstract
+   *
+   * @return Promise<Object>
+   */
+  _upsert() {
+    throw new Error("You have to implement the method '_upsert'!");
+  }
 };

--- a/lib/RateLimiterStoreAbstract.js
+++ b/lib/RateLimiterStoreAbstract.js
@@ -293,6 +293,15 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterAbstract {
   }
 
   /**
+   * Cleanup keys no-matter expired or not.
+   * 
+   * @param {string|undefined} key
+   */
+  cleanupInmemory(key) {
+    this._inmemoryBlockedKeys.cleanup(key);
+  }
+
+  /**
    * Get RateLimiterRes object filled depending on storeResult, which specific for exact store
    *
    * @param rlKey

--- a/lib/RateLimiterStoreAbstract.js
+++ b/lib/RateLimiterStoreAbstract.js
@@ -284,7 +284,7 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterAbstract {
     return new Promise((resolve, reject) => {
       this._delete(rlKey, options)
         .then((res) => {
-          this._inmemoryBlockedKeys.delete(key);
+          this._inmemoryBlockedKeys.delete(rlKey);
           resolve(res);
         })
         .catch((err) => {

--- a/lib/component/BlockedKeys/BlockedKeys.js
+++ b/lib/component/BlockedKeys/BlockedKeys.js
@@ -59,9 +59,11 @@ module.exports = class BlockedKeys {
   }
 
   /**
+   * If key is not given, delete all data in memory
+   * 
    * @param {string|undefined} key
    */
-  cleanup(key) {
+  delete(key) {
     if (key) {
       delete this._keys[key];
     } else {

--- a/lib/component/BlockedKeys/BlockedKeys.js
+++ b/lib/component/BlockedKeys/BlockedKeys.js
@@ -57,4 +57,17 @@ module.exports = class BlockedKeys {
 
     return 0;
   }
+
+  /**
+   * @param {string|undefined} key
+   */
+  cleanup(key) {
+    if (key) {
+      delete this._keys[key];
+    } else {
+      Object.keys(this._keys).forEach((key) => {
+        delete this._keys[key];
+      });
+    }
+  }
 };

--- a/test/RateLimiterStoreAbstract.test.js
+++ b/test/RateLimiterStoreAbstract.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable security/detect-object-injection */
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const RateLimiterStoreAbstract = require('../lib/RateLimiterStoreAbstract');
+const RateLimiterRes = require('../lib/RateLimiterRes');
+
+class RateLimiterStoreMemory extends RateLimiterStoreAbstract {
+  constructor(opts) {
+    super(opts);
+    this._inMemoryDataAsStorage = {};
+  }
+
+  _getRateLimiterRes(rlKey, changedPoints, storeResult) {
+    const res = new RateLimiterRes();
+    res.consumedPoints = storeResult.points;
+    res.isFirstInDuration = res.consumedPoints === changedPoints;
+    res.remainingPoints = Math.max(this.points - res.consumedPoints, 0);
+    res.msBeforeNext = storeResult.msBeforeNext;
+    return res;
+  }
+
+  _get(rlKey) {
+    const result = this._inMemoryDataAsStorage[rlKey];
+
+    return Promise.resolve(typeof result === 'undefined' ? null : result);
+  }
+
+  _delete(rlKey) {
+    const value = this._inMemoryDataAsStorage[rlKey];
+
+    if (typeof value === 'undefined') {
+      return Promise.resolve(false);
+    }
+
+    delete this._inMemoryDataAsStorage[rlKey];
+    return Promise.resolve(true);
+  }
+
+  _upsert(rlKey, points, msDuration) {
+    const now = Date.now();
+    const result = {
+      points,
+      msBeforeNext: msDuration,
+    };
+
+    if (typeof this._inMemoryDataAsStorage[rlKey] === 'undefined') {
+      this._inMemoryDataAsStorage[rlKey] = {
+        points,
+        expired: now + msDuration,
+      };
+    } else {
+      const value = this._inMemoryDataAsStorage[rlKey];
+      if (value.expired > now) {
+        value.points += points;
+        result.points = value.points;
+        result.msBeforeNext = value.expired - now;
+      } else {
+        value.points = points;
+        value.expired = now + msDuration;
+      }
+    }
+
+    return Promise.resolve(result);
+  }
+}
+
+describe('RateLimiterStoreAbstract with fixed window', () => {
+  it('delete all in memory blocked keys', (done) => {
+    const rateLimiter = new RateLimiterStoreMemory({
+      points: 1,
+      duration: 1,
+      // avoid fire block method
+      blockDuration: 0,
+      inmemoryBlockOnConsumed: 1,
+      inmemoryBlockDuration: 1,
+      keyPrefix: '',
+    });
+
+    // should start blocking
+    Promise.allSettled([
+      rateLimiter.consume('key1', 2),
+      rateLimiter.consume('key2', 2),
+    ])
+      .then(() => {
+        expect(rateLimiter._inmemoryBlockedKeys._keys.key1).not.eq(undefined);
+        expect(rateLimiter._inmemoryBlockedKeys._keys.key2).not.eq(undefined);
+
+        rateLimiter.deleteInMemory();
+        expect(rateLimiter._inmemoryBlockedKeys._keys.key1).eq(undefined);
+        expect(rateLimiter._inmemoryBlockedKeys._keys.key2).eq(undefined);
+
+        done();
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('delete specific key should also deleting in-memory data', (done) => {
+    const rateLimiter = new RateLimiterStoreMemory({
+      points: 1,
+      duration: 1,
+      // avoid fire block method
+      blockDuration: 0,
+      inmemoryBlockOnConsumed: 1,
+      inmemoryBlockDuration: 1,
+      keyPrefix: '',
+    });
+
+    // should start blocking
+    rateLimiter.consume('key', 2).catch(() => {
+      expect(rateLimiter._inmemoryBlockedKeys._keys.key).not.eq(undefined);
+
+      rateLimiter.delete('key').then((isExist) => {
+        expect(rateLimiter._inmemoryBlockedKeys._keys.key).eq(undefined);
+        expect(isExist).eq(true);
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
It is required when we need to manually allow specific blocked clients to pass the limiter.