### PR TITLE
Remove timeout on deletion of node

### DIFF
--- a/lib/component/MemoryStorage/MemoryStorage.js
+++ b/lib/component/MemoryStorage/MemoryStorage.js
@@ -72,6 +72,9 @@ module.exports = class MemoryStorage {
    */
   delete(key) {
     if (this._storage[key]) {
+      if (this._storage[key].timeoutId) {
+        clearTimeout(this._storage[key].timeoutId);
+      }
       delete this._storage[key];
       return true;
     }


### PR DESCRIPTION
When using the delete function, I noticed that the timeouts are not cleared. This causes the timeout to be executed even if the item was already deleted. If there is already a new item with the same key in the meantime, that one will be removed.