### PR TITLE
Add "browser" field to allow bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
     "mocha": "^5.1.1",
     "redis-mock": "^0.48.0",
     "sinon": "^5.0.10"
+  },
+  "browser": {
+    "cluster": false,
+    "crypto": false
   }
 }


### PR DESCRIPTION
Since bundlers don't tend to add shims for node core modules any more, it's necessary to tell them what to do when the code imports a given node core module.

The change allows use of things like `RateLimiterMemory` in isomorphic js code.