### PR TITLE
replace "util.inspect.custom" by global Symbol for more flexible

### DIFF
--- a/lib/RateLimiterRes.js
+++ b/lib/RateLimiterRes.js
@@ -1,5 +1,3 @@
-const util = require('util');
-
 module.exports = class RateLimiterRes {
   constructor(remainingPoints, msBeforeNext, consumedPoints, isFirstInDuration) {
     this.remainingPoints = typeof remainingPoints === 'undefined' ? 0 : remainingPoints; // Remaining points in current duration
@@ -52,7 +50,7 @@ module.exports = class RateLimiterRes {
     };
   }
 
-  [util.inspect.custom]() {
+  [Symbol.for("nodejs.util.inspect.custom")]() {
     return this._getDecoratedProperties();
   }
 


### PR DESCRIPTION
As the node js documentation says, you need to use a global symbol to can be accessed in any environment for "util.inspect.custom":

https://nodejs.org/api/util.html#utilinspectcustom

> In addition to being accessible through util.inspect.custom, this symbol is [registered globally](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for) and can be accessed in any environment as Symbol.for('nodejs.util.inspect.custom').

Otherwise when building js-libp2p app for browser using Vite, you can catch the following error:

![image](https://user-images.githubusercontent.com/2076748/189537523-3f438fea-498c-4c64-92f1-b06d5bbd922b.png)
