### PR TITLE
RateLimiterRedis: track redis connection state

### DIFF
--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -37,6 +37,25 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
     }
   }
 
+  /**
+   * Prevent actual redis call if redis connection is not ready.
+   * Because of different connection state checks for ioredis and node-redis, only this clients would be actually checked.
+   * For any other clients all the requests would be passed directly to client
+   * @return {boolean}
+   * @private
+   */
+  _isRedisReady() {
+    // ioredis client
+    if (this.client.status && this.client.status !== 'ready') {
+      return false;
+    }
+    // node-redis client
+    if (typeof this.client.isReady === 'function' && !this.client.isReady()) {
+      return false;
+    }
+    return true;
+  }
+
   _getRateLimiterRes(rlKey, changedPoints, result) {
     let [consumed, resTtlMs] = result;
     // Support ioredis results format
@@ -56,6 +75,10 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
 
   _upsert(rlKey, points, msDuration, forceExpire = false) {
     return new Promise((resolve, reject) => {
+      if (!this._isRedisReady()) {
+        return reject(new Error('Not connected'));
+      }
+
       const secDuration = Math.floor(msDuration / 1000);
       const multi = this.client.multi();
       if (forceExpire) {
@@ -105,6 +128,10 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
 
   _get(rlKey) {
     return new Promise((resolve, reject) => {
+      if (!this._isRedisReady()) {
+        return reject(new Error('Not connected'));
+      }
+
       this.client
         .multi()
         .get(rlKey)

--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -30,7 +30,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
       this.client = opts.storeClient;
     }
 
-    this.rejectIfRedisNotReady = !!opts.rejectIfRedisNotReady;
+    this._rejectIfRedisNotReady = !!opts.rejectIfRedisNotReady;
 
     if (typeof this.client.defineCommand === 'function') {
       this.client.defineCommand("rlflxIncr", {
@@ -48,7 +48,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
    * @private
    */
   _isRedisReady() {
-    if (!this.rejectIfRedisNotReady) {
+    if (!this._rejectIfRedisNotReady) {
       return true;
     }
     // ioredis client

--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -19,6 +19,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
    *   ... see other in RateLimiterStoreAbstract
    *
    *   redis: RedisClient
+   *   rejectIfRedisNotReady: boolean = false - reject / invoke insuranceLimiter immediately when redis connection is not "ready"
    * }
    */
   constructor(opts) {
@@ -29,6 +30,8 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
       this.client = opts.storeClient;
     }
 
+    this.rejectIfRedisNotReady = !!opts.rejectIfRedisNotReady;
+
     if (typeof this.client.defineCommand === 'function') {
       this.client.defineCommand("rlflxIncr", {
         numberOfKeys: 1,
@@ -38,13 +41,16 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   }
 
   /**
-   * Prevent actual redis call if redis connection is not ready.
+   * Prevent actual redis call if redis connection is not ready and insuranceLimiter is present
    * Because of different connection state checks for ioredis and node-redis, only this clients would be actually checked.
-   * For any other clients all the requests would be passed directly to client
+   * For any other clients all the requests would be passed directly to redis client
    * @return {boolean}
    * @private
    */
   _isRedisReady() {
+    if (!this.rejectIfRedisNotReady) {
+      return true;
+    }
     // ioredis client
     if (this.client.status && this.client.status !== 'ready') {
       return false;
@@ -76,7 +82,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   _upsert(rlKey, points, msDuration, forceExpire = false) {
     return new Promise((resolve, reject) => {
       if (!this._isRedisReady()) {
-        return reject(new Error('Not connected'));
+        return reject(new Error('Redis connection is not ready'));
       }
 
       const secDuration = Math.floor(msDuration / 1000);
@@ -129,7 +135,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   _get(rlKey) {
     return new Promise((resolve, reject) => {
       if (!this._isRedisReady()) {
-        return reject(new Error('Not connected'));
+        return reject(new Error('Redis connection is not ready'));
       }
 
       this.client

--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -41,7 +41,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   }
 
   /**
-   * Prevent actual redis call if redis connection is not ready and insuranceLimiter is present
+   * Prevent actual redis call if redis connection is not ready
    * Because of different connection state checks for ioredis and node-redis, only this clients would be actually checked.
    * For any other clients all the requests would be passed directly to redis client
    * @return {boolean}

--- a/test/RateLimiterRedis.test.js
+++ b/test/RateLimiterRedis.test.js
@@ -551,6 +551,48 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
       });
   });
 
+  describe('disconnected redis client', () => {
+    it('get points with disconnected ioredis', (done) => {
+      const testKey = 'get';
+
+      const disconnectedIoRedis = {
+        status: 'closed',
+      };
+
+      const rateLimiter = new RateLimiterRedis({
+        storeClient: disconnectedIoRedis,
+        points: 2,
+        duration: 1,
+      });
+      rateLimiter
+        .consume(testKey)
+        .catch((error) => {
+          expect(error.message).to.equal('Not connected');
+          done();
+        });
+    });
+
+    it('get points with disconnected node-redis', (done) => {
+      const testKey = 'get';
+
+      const disconnectedIoRedis = {
+        isReady: () => false,
+      };
+
+      const rateLimiter = new RateLimiterRedis({
+        storeClient: disconnectedIoRedis,
+        points: 2,
+        duration: 1,
+      });
+      rateLimiter
+        .consume(testKey)
+        .catch((error) => {
+          expect(error.message).to.equal('Not connected');
+          done();
+        });
+    });
+  });
+
   it('get returns NULL if key is not set', (done) => {
     const testKey = 'getnull';
 

--- a/test/RateLimiterRedis.test.js
+++ b/test/RateLimiterRedis.test.js
@@ -552,7 +552,40 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   });
 
   describe('disconnected redis client', () => {
-    it('get points with disconnected ioredis', (done) => {
+    it('attempt to invoke redis if rejectIfRedisNotReady is not set', (done) => {
+      const testKey = 'get';
+
+      const rateLimiter = new RateLimiterRedis({
+        storeClient: redisClientClosed,
+        points: 2,
+        duration: 1,
+      });
+      rateLimiter
+        .consume(testKey)
+        .catch((error) => {
+          expect(error.message).to.equal('closed');
+          done();
+        });
+    });
+
+    it('get throws error with mock redis', (done) => {
+      const testKey = 'get';
+
+      const rateLimiter = new RateLimiterRedis({
+        storeClient: redisClientClosed,
+        points: 2,
+        duration: 1,
+        rejectIfRedisNotReady: true,
+      });
+      rateLimiter
+        .consume(testKey)
+        .catch((error) => {
+          expect(error.message).to.equal('Redis connection is not ready');
+          done();
+        });
+    });
+
+    it('get throws error with disconnected ioredis', (done) => {
       const testKey = 'get';
 
       const disconnectedIoRedis = {
@@ -563,16 +596,17 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
         storeClient: disconnectedIoRedis,
         points: 2,
         duration: 1,
+        rejectIfRedisNotReady: true,
       });
       rateLimiter
         .consume(testKey)
         .catch((error) => {
-          expect(error.message).to.equal('Not connected');
+          expect(error.message).to.equal('Redis connection is not ready');
           done();
         });
     });
 
-    it('get points with disconnected node-redis', (done) => {
+    it('get throws error with disconnected node-redis', (done) => {
       const testKey = 'get';
 
       const disconnectedIoRedis = {
@@ -583,11 +617,12 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
         storeClient: disconnectedIoRedis,
         points: 2,
         duration: 1,
+        rejectIfRedisNotReady: true,
       });
       rateLimiter
         .consume(testKey)
         .catch((error) => {
-          expect(error.message).to.equal('Not connected');
+          expect(error.message).to.equal('Redis connection is not ready');
           done();
         });
     });


### PR DESCRIPTION
Pass get() and consume() calls directly to insuranceLimiter if redis connection is not ready

This PR is to fix [Issue 184](https://github.com/animir/node-rate-limiter-flexible/issues/184), and prevent slow response without falling back to insuranceLimiter if redis connection is lost