### PR TITLE
Add new option rejectIfRedisNotReady for RateLimiterRedis to index.d.ts

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -255,6 +255,10 @@ interface IRateLimiterMongoOptions extends IRateLimiterStoreOptions {
     };
 }
 
+interface IRateLimiterRedisOptions extends IRateLimiterStoreOptions {
+  rejectIfRedisNotReady?: boolean;
+}
+
 interface ICallbackReady {
     (error?: Error): void;
 }
@@ -284,7 +288,9 @@ export class RateLimiterClusterMasterPM2 {
     constructor(pm2: any);
 }
 
-export class RateLimiterRedis extends RateLimiterStoreAbstract {}
+export class RateLimiterRedis extends RateLimiterStoreAbstract {
+  constructor(opts: IRateLimiterRedisOptions);
+}
 
 export interface IRateLimiterMongoFunctionOptions {
     attrs: { [key: string]: any };


### PR DESCRIPTION
Extend `IRateLimiterStoreOptions` type with `IRateLimiterRedisOptions` with new redis storage option `rejectIfRedisNotReady` to use its constructor from TS