### PR TITLE
Add clearExpiredByTimeout to RateLimiterPostgres.js

### DIFF
--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -48,6 +48,9 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
           }
         });
     } else {
+      if (this.clearExpiredByTimeout) {
+        this._clearExpiredHourAgo();
+      }
       if (typeof cb === 'function') {
         cb();
       }


### PR DESCRIPTION
This commit adds clearExpiredByTimeout feature to RateLimiterPostgres.js when table is already created.

If there is not a reason this is missing and MySQL has it, then Postgres should support this, too.