### PR TITLE
chore: start DynamoDB local with docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,8 @@ services:
     container_name: cache
     ports:
       - 6379:6379
+  dynamodb:
+    image: amazon/dynamodb-local
+    container_name: dynamo
+    ports:
+      - 8000:8000

--- a/test/RateLimiterDynamo.test.js
+++ b/test/RateLimiterDynamo.test.js
@@ -4,10 +4,6 @@ const { describe, it } = require('mocha');
 const RateLimiterDynamo = require('../lib/RateLimiterDynamo');
 const sinon = require('sinon');
 
-/*
-    In order to perform this tests, you need to run a local instance of dynamodb:
-    docker run -p 8000:8000 amazon/dynamodb-local
-*/
 describe('RateLimiterDynamo with fixed window', function RateLimiterDynamoTest() {
     this.timeout(5000);
 


### PR DESCRIPTION
This removes the need for starting it separately, leaving the use with only one command to run before running tests