### PR TITLE
chore: Fix coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 coverage
 package-lock.json
+.nyc_output/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dc:up": "docker-compose -f docker-compose.yml up -d",
     "dc:down": "docker-compose -f docker-compose.yml down",
-    "test": "istanbul -v cover -- _mocha --recursive",
+    "test": "nyc  --reporter=html --reporter=text mocha",
     "debug-test": "mocha --inspect-brk lib/**/**.test.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "eslint": "eslint --quiet lib/**/**.js test/**/**.js",
@@ -53,6 +53,7 @@
     "istanbul": "^1.1.0-alpha.1",
     "memcached-mock": "^0.1.0",
     "mocha": "^10.2.0",
+    "nyc": "^15.1.0",
     "redis": "^4.6.8",
     "redis-mock": "^0.48.0",
     "sinon": "^5.0.10"


### PR DESCRIPTION
By adding `nyc` dependency, we can get complete coverage reports, both as HTML and inline summary in CLI.

### Before

When using `istanbul` directly, we see a lot of errors in the console and the HTML report looks a bit weird.

#### Running tests

```sh
  300 passing (1m)

=============================================================================
Writing coverage object [/Users/morgan/code/mroderick/node-rate-limiter-flexible/coverage/coverage.raw.json]
Writing coverage reports at [/Users/morgan/code/mroderick/node-rate-limiter-flexible/coverage]
=============================================================================
Handlebars: Access has been denied to resolve the property "statements" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
Handlebars: Access has been denied to resolve the property "branches" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
Handlebars: Access has been denied to resolve the property "functions" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
Handlebars: Access has been denied to resolve the property "lines" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details

=============================== Coverage summary ===============================
Statements   : 77.42% ( 1032/1333 )
Branches     : 73.82% ( 595/806 )
Functions    : 80.57% ( 340/422 )
Lines        : 77.43% ( 1026/1325 )
================================================================================
```

#### HTML report

<img width="1180" alt="image" src="https://github.com/animir/node-rate-limiter-flexible/assets/20321/aa6beef2-b440-4072-ae23-cb6cbc28bc84">

### After

When using `istanbul` through `nyc`, all the errors in the console are gone and the HTML report renders properly.

#### Running tests

```sh
  281 passing (55s)

--------------------------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------
File                                                    | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------
All files                                               |   77.13 |     73.2 |   80.37 |   77.13 |
 node-rate-limiter-flexible                             |     100 |      100 |     100 |     100 |
  index.js                                              |     100 |      100 |     100 |     100 |
 node-rate-limiter-flexible/lib                         |    75.8 |    72.52 |    79.3 |   75.78 |
  BurstyRateLimiter.js                                  |     100 |      100 |     100 |     100 |
  ExpressBruteFlexible.js                               |     9.8 |        0 |       0 |    9.93 | 17-23,27-53,59-248,256-275,285-293,297-298,301-303,311-313,321-324,335
  RLWrapperBlackAndWhite.js                             |   96.38 |    93.54 |    87.5 |   96.29 | 19,50,72
  RateLimiterAbstract.js                                |   77.14 |    86.36 |      72 |   77.14 | 79,99-123
  RateLimiterCluster.js                                 |   74.62 |    65.47 |   74.28 |   74.62 | 53-58,78,86,111,152,180,187-188,228-274
  RateLimiterDynamo.js                                  |    76.4 |    62.06 |   88.88 |    76.4 | 60-73,125,130,145,177,220,261,285,297,312,323-335,349,362
  RateLimiterMemcache.js                                |   91.93 |    81.25 |     100 |   91.93 | 51,88,114,133,139
  RateLimiterMemory.js                                  |     100 |    96.42 |     100 |     100 | 6
  RateLimiterMongo.js                                   |      80 |    71.18 |   80.76 |   79.77 | 45,51-55,119,137,204-232,244,262
  RateLimiterMySQL.js                                   |   74.65 |    62.16 |   85.45 |   74.65 | ...77,80-82,99,108,119-121,143-144,152,172-179,236-238,270-272,276-278,283-285,298,310-315,322,333,345,352,373
  RateLimiterPostgres.js                                |   87.96 |    83.33 |   85.71 |   87.96 | 47,65-77,89,92-94,153,265,293,317
  RateLimiterQueue.js                                   |   92.59 |    82.14 |     100 |   92.59 | 68,76,117-118
  RateLimiterRedis.js                                   |   86.11 |     86.2 |   81.81 |   85.71 | 60,111-123,143
  RateLimiterRes.js                                     |      95 |      100 |    92.3 |      95 | 54
  RateLimiterStoreAbstract.js                           |    92.3 |    87.01 |   89.58 |    92.3 | 31,104,149,200,312,350-382
  RateLimiterUnion.js                                   |   96.42 |    93.33 |     100 |   96.15 | 6
  constants.js                                          |     100 |      100 |     100 |     100 |
 node-rate-limiter-flexible/lib/component               |    87.5 |       50 |     100 |    87.5 |
  RateLimiterQueueError.js                              |    87.5 |       50 |     100 |    87.5 | 10
 node-rate-limiter-flexible/lib/component/BlockedKeys   |      92 |       75 |     100 |      92 |
  BlockedKeys.js                                        |    91.3 |       75 |     100 |    91.3 | 12,39
  index.js                                              |     100 |      100 |     100 |     100 |
 node-rate-limiter-flexible/lib/component/MemoryStorage |   97.67 |     90.9 |     100 |   97.67 |
  MemoryStorage.js                                      |     100 |    92.85 |     100 |     100 | 45,75
  Record.js                                             |   91.66 |       80 |     100 |   91.66 | 28
--------------------------------------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------------------------------------
```

#### HTML report

<img width="1177" alt="image" src="https://github.com/animir/node-rate-limiter-flexible/assets/20321/5b561a00-c586-4f67-a02b-b3f293f79a2d">

