### PR TITLE
chore: Prefer async functions

### DIFF
--- a/test/RateLimiterRedis.redis.test.js
+++ b/test/RateLimiterRedis.redis.test.js
@@ -20,24 +20,18 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
     await redisMockClient.quit();
   })
 
-  it('consume 1 point', (done) => {
+  it('consumes 1 point', async () => {
     const testKey = 'consume1';
     const rateLimiter = new RateLimiterRedis({
       storeClient: redisMockClient,
       points: 2,
       duration: 5,
     });
-    rateLimiter
-      .consume(testKey)
-      .then(() => {
-        redisMockClient.get(rateLimiter.getKey(testKey)).then((consumedPoints)=>{
-          expect(consumedPoints).to.equal('1');
-          done();
-        });
-      })
-      .catch((err) => {
-        done(err);
-      });
+    await rateLimiter.consume(testKey);
+
+    const consumedPoints = await redisMockClient.get(rateLimiter.getKey(testKey));
+
+    expect(consumedPoints).to.equal('1');
   });
 
   it('rejected when consume more than maximum points', (done) => {


### PR DESCRIPTION
Since the codebase already uses async/await and requires node 14+, it might as well use async/await instead of then for Promises

By using async/await we can reduce the indentation levels, which generally makes the code easier to understand.

If refactoring like this is welcome, then I will expand on this PR to tidy up the test file and the source file it tests. Future PRs can tidy up other file pairs.