### PR TITLE
Fix client version for RateLimiterMongo

### DIFF
--- a/lib/RateLimiterMongo.js
+++ b/lib/RateLimiterMongo.js
@@ -10,8 +10,14 @@ function getDriverVersion(client) {
   try {
     const _client = client.client ? client.client : client;
 
-    const { version } = _client.topology.s.options.metadata.driver;
-    const _v = version.split('.').map(v => parseInt(v));
+    let _v = [0, 0, 0];
+    if (typeof _client.topology === 'undefined') {
+      const { version } = _client.options.metadata.driver;
+      _v = version.split('|', 1)[0].split('.').map(v => parseInt(v));
+    } else {
+      const { version } = _client.topology.s.options.metadata.driver;
+      _v = version.split('.').map(v => parseInt(v));
+    }
 
     return {
       major: _v[0],


### PR DESCRIPTION
The getDriverVersion logic is resulting in a 0.0.0 version on the latest mongoose + mongodb versions due to topology being undefined, added logic to process the version properly if the field is undefined.

Details of the error can be found here: https://github.com/animir/node-rate-limiter-flexible/issues/251 