### PR TITLE
chore: prefer 127.0.0.1 over 'localhost' in tests

### DIFF
--- a/test/ExpressBruteFlexible.test.js
+++ b/test/ExpressBruteFlexible.test.js
@@ -7,6 +7,7 @@ const Memcached = require('memcached-mock');
 const ExpressBruteFlexible = require('../lib/ExpressBruteFlexible');
 const limiters = require('../index');
 const redis = require("redis");
+const redisOptions = require('./RedisOptions');
 
 const makeRequest = (middleware, req, res, next) => new Promise((resolve) => {
   middleware(req, res, (err) => {
@@ -32,7 +33,7 @@ describe('ExpressBruteFlexible', async function ExpressBruteFlexibleTest() {
   };
 
   const memcacheMockClient = new Memcached('localhost:11211');
-  const redisMockClient = redis.createClient();
+  const redisMockClient = redis.createClient(redisOptions);
   await redisMockClient.connect();
   await redisMockClient.flushAll();
 

--- a/test/RateLimiterDynamo.test.js
+++ b/test/RateLimiterDynamo.test.js
@@ -13,7 +13,7 @@ describe('RateLimiterDynamo with fixed window', function RateLimiterDynamoTest()
             accessKeyId: 'fake', 
             secretAccessKey: 'fake'
         },
-        endpoint: 'http://localhost:8000'
+        endpoint: 'http://127.0.0.1:8000'
     });
     
     it('DynamoDb client connection', (done) => {

--- a/test/RateLimiterRedis.ioredis.test.js
+++ b/test/RateLimiterRedis.ioredis.test.js
@@ -11,8 +11,11 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   let redisMockClient;
 
   beforeEach(async () => {
-    redisMockClient = new Redis();
-    //await redisMockClient.connect();
+    redisMockClient = new Redis({
+      port: 6379, // Redis port
+      host: '127.0.0.1', // Redis host
+    });
+    // await redisMockClient.connect();
   });
 
   afterEach(async ()=>{

--- a/test/RateLimiterRedis.redis.test.js
+++ b/test/RateLimiterRedis.redis.test.js
@@ -5,13 +5,14 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const RateLimiterRedis = require('../lib/RateLimiterRedis');
 const redis = require("redis");
+const redisOptions = require('./RedisOptions');
 
 describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   this.timeout(5500);
   let redisMockClient;
 
   beforeEach(async () => {
-    redisMockClient = redis.createClient();
+    redisMockClient = redis.createClient(redisOptions);
     await redisMockClient.connect();
     await redisMockClient.flushAll();
   });
@@ -325,7 +326,7 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   it('consume using insuranceLimiter when RedisClient error', async() => {
     const testKey = 'rediserror2';
 
-    const redisClientClosed = redis.createClient();
+    const redisClientClosed = redis.createClient(redisOptions);
     await redisClientClosed.connect();
 
     const rateLimiter = new RateLimiterRedis({
@@ -353,7 +354,7 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   it('penalty using insuranceLimiter when RedisClient error', async () => {
     const testKey = 'rediserror3';
 
-    const redisClientClosed = redis.createClient();
+    const redisClientClosed = redis.createClient(redisOptions);
     await redisClientClosed.connect();
 
     const rateLimiter = new RateLimiterRedis({
@@ -380,7 +381,7 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   it('reward using insuranceLimiter when RedisClient error', async () => {
     const testKey = 'rediserror4';
 
-    const redisClientClosed = redis.createClient();
+    const redisClientClosed = redis.createClient(redisOptions);
     await redisClientClosed.connect();
 
     const rateLimiter = new RateLimiterRedis({
@@ -413,7 +414,7 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   it('block using insuranceLimiter when RedisClient error', async() => {
     const testKey = 'rediserrorblock';
 
-    const redisClientClosed = redis.createClient();
+    const redisClientClosed = redis.createClient(redisOptions);
     await redisClientClosed.connect();
 
     const rateLimiter = new RateLimiterRedis({
@@ -717,7 +718,7 @@ describe('RateLimiterRedis with fixed window', function RateLimiterRedisTest() {
   it('insurance limiter on error consume applies options.customDuration to set expire', async () => {
     const testKey = 'consume.customDuration.onerror';
 
-    const redisClientClosed = redis.createClient();
+    const redisClientClosed = redis.createClient(redisOptions);
     await redisClientClosed.connect();
 
     const rateLimiter = new RateLimiterRedis({

--- a/test/RedisOptions.js
+++ b/test/RedisOptions.js
@@ -1,0 +1,9 @@
+// This object is used for setting the options for the redis client,
+// so we can connect to the redis server in Docker, using ipv4 and not
+// ipv6, which the client defaults to useing
+module.exports = {
+  socket: {
+    host: '127.0.0.1',
+    port: 6379,
+  },
+};


### PR DESCRIPTION
Using 'localhost' causes problems on some systems, as redis client will try to connect to Docker using ipv6 (::1) instead of using ipv4. By using an ipv4 address (127.0.0.1), we're forcing use of ipv4, which works on more systems

---

Background: I was unable to run the tests successfully on my work computer, whereas they run fine on my personal computer. This PR should make it easier for more people (like myself) to contribute.