### PR TITLE
chore: also use cached npm packages for ESlint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: ./package.json
       - name: Install dependencies
         run: |
           npm install


### PR DESCRIPTION
This PR instructs GitHub Actions to also use cache for npm packages for the ESLint job. This will likely give a minor speedup for this job, and may prime the cache for the following job :)