### PR TITLE
RateLimiterDynamo: Add key to skip querying ttl

### DIFF
--- a/lib/RateLimiterDynamo.js
+++ b/lib/RateLimiterDynamo.js
@@ -40,6 +40,7 @@ class RateLimiterDynamo extends RateLimiterStoreAbstract {
         this.client = opts.storeClient;
         this.tableName = opts.tableName;
         this.tableCreated = opts.tableCreated;
+        this.ttlManuallySet = opts.ttlSet;
         
         if (!this.tableCreated) {
           this._createTable(opts.dynamoTableOpts)
@@ -347,6 +348,10 @@ class RateLimiterDynamo extends RateLimiterStoreAbstract {
       
       if (!this.tableCreated) {
         throw new Error('Table is not created yet');
+      }
+
+      if (this.ttlManuallySet) {
+        return true;
       }
 
       try {


### PR DESCRIPTION
TLDR: Adds an option allowing users to skip the check for TTL settings when using the `RateLimiterDynamo`.

When assessing this library for use in a serverless environment (in this case AWS Lambda), we noticed that there was a significant overhead every time we instantiated a new rate limiter (so every time a new lambda started). This was due to `RateLimiterDynamo`'s behaviour which is to query the table to make sure that the TTL has been set up correctly.

While this is useful behavior on a long-running server, it doesn't make much sense in a serverless environment - once we've validated that the TTL is indeed set up correctly it doesn't make sense to keep checking it again and again and again.

I propose a new option which disables this check, in much the same way that you can disable `RateLimiterDynamo`'s built-in table-creation logic.