### PR TITLE
fix(prisma): cleanup expiry timeout when process exits to prevent memory leak

### DIFF
--- a/lib/RateLimiterPrisma.js
+++ b/lib/RateLimiterPrisma.js
@@ -20,6 +20,12 @@ class RateLimiterPrisma extends RateLimiterStoreAbstract {
     if (this.clearExpiredByTimeout) {
       this._clearExpiredHourAgo();
     }
+
+    process.on('SIGTERM', () => {
+      if (this._clearExpiredTimeoutId) {
+        clearTimeout(this._clearExpiredTimeoutId);
+      }
+    });
   }
 
   _getRateLimiterRes(rlKey, changedPoints, result) {

--- a/lib/RateLimiterPrisma.js
+++ b/lib/RateLimiterPrisma.js
@@ -20,12 +20,6 @@ class RateLimiterPrisma extends RateLimiterStoreAbstract {
     if (this.clearExpiredByTimeout) {
       this._clearExpiredHourAgo();
     }
-
-    process.on('SIGTERM', () => {
-      if (this._clearExpiredTimeoutId) {
-        clearTimeout(this._clearExpiredTimeoutId);
-      }
-    });
   }
 
   _getRateLimiterRes(rlKey, changedPoints, result) {
@@ -126,6 +120,7 @@ class RateLimiterPrisma extends RateLimiterStoreAbstract {
       });
       this._clearExpiredHourAgo();
     }, 300000); // Clear every 5 minutes
+    this._clearExpiredTimeoutId.unref();
   }
 }
 


### PR DESCRIPTION
I noticed my app had hanging child processes when shutting down after introducing `RateLimiterPrisma`. Tracked it down to this timeout handler which is not being cleaned up