### PR TITLE
fix(SQLite): close unclosed Knex connection

### DIFF
--- a/lib/RateLimiterSQLite.js
+++ b/lib/RateLimiterSQLite.js
@@ -217,8 +217,7 @@ class RateLimiterSQLite extends RateLimiterStoreAbstract {
     return res;
   }
 
-  async _upsertTransactionSQLite3(upsertQuery, upsertParams) {
-    const conn = await this._getConnection();
+  async _upsertTransactionSQLite3(conn, upsertQuery, upsertParams) {
     return await new Promise((resolve, reject) => {
       conn.serialize(() => {
         conn.run("SAVEPOINT rate_limiter_trx;", (err) => {
@@ -237,9 +236,7 @@ class RateLimiterSQLite extends RateLimiterStoreAbstract {
     });
   }
 
-  async _upsertTransactionBetterSQLite3(upsertQuery, upsertParams) {
-    const conn = await this._getConnection();
-
+  async _upsertTransactionBetterSQLite3(conn, upsertQuery, upsertParams) {
     return conn.transaction(() =>
       conn.prepare(upsertQuery).get(...upsertParams)
     )();
@@ -263,9 +260,14 @@ class RateLimiterSQLite extends RateLimiterStoreAbstract {
     try {
       switch (this._internalStoreType) {
         case "sqlite3":
-          return this._upsertTransactionSQLite3(upsertQuery, upsertParams);
+          return this._upsertTransactionSQLite3(
+            conn,
+            upsertQuery,
+            upsertParams
+          );
         case "better-sqlite3":
           return this._upsertTransactionBetterSQLite3(
+            conn,
             upsertQuery,
             upsertParams
           );

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "ioredis": "^5.3.2",
     "iovalkey": "^0.3.1",
     "istanbul": "^1.1.0-alpha.1",
+    "knex": "^3.1.0",
     "memcached-mock": "^0.1.0",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",

--- a/test/RateLimiterSQLite.test.js
+++ b/test/RateLimiterSQLite.test.js
@@ -3,6 +3,7 @@ const { expect } = require("chai");
 const sqlite3 = require("sqlite3");
 const betterSQLite3 = require("better-sqlite3");
 const { RateLimiterSQLite } = require("../index");
+const knex = require("knex");
 
 function testRateLimiterSQLite(library, createDb) {
   describe(`RateLimiterSQLite with ${library}`, () => {
@@ -218,3 +219,19 @@ testRateLimiterSQLite("sqlite3", () => new sqlite3.Database(":memory:"));
 
 // Run tests with better-sqlite3 in-memory-database
 testRateLimiterSQLite("better-sqlite3", () => new betterSQLite3(":memory:"));
+
+// Run test with knex using better-sqlite3 in-memory database
+testRateLimiterSQLite("knex", () =>
+  knex({
+    client: "better-sqlite3",
+    connection: { filename: ":memory:" },
+  })
+);
+
+// Run test with knex using sqlite3 in-memory database
+testRateLimiterSQLite("knex", () =>
+  knex({
+    client: "sqlite3",
+    connection: { filename: ":memory:" },
+  })
+);

--- a/test/RateLimiterSQLite.test.js
+++ b/test/RateLimiterSQLite.test.js
@@ -5,8 +5,8 @@ const betterSQLite3 = require("better-sqlite3");
 const { RateLimiterSQLite } = require("../index");
 const knex = require("knex");
 
-function testRateLimiterSQLite(library, createDb) {
-  describe(`RateLimiterSQLite with ${library}`, () => {
+function testRateLimiterSQLite(library, createDb, clientName = null) {
+  describe(`RateLimiterSQLite with ${clientName || library}`, () => {
     let db;
     let rateLimiter;
 
@@ -26,10 +26,15 @@ function testRateLimiterSQLite(library, createDb) {
     afterEach((done) => {
       if (library === "sqlite3") {
         db.close(() => done());
-      } else {
-        db.close();
-        done();
+        return;
       }
+
+      if (library === "knex") {
+        db.destroy().then(() => done());
+        return;
+      }
+      db.close();
+      done();
     });
 
     describe("basic functionality", () => {
@@ -125,6 +130,8 @@ function testRateLimiterSQLite(library, createDb) {
         // Close the database to simulate errors
         if (library === "sqlite3") {
           await new Promise((resolve) => db.close(resolve));
+        } else if (library === "knex") {
+          await db.destroy();
         } else {
           db.close();
         }
@@ -221,17 +228,25 @@ testRateLimiterSQLite("sqlite3", () => new sqlite3.Database(":memory:"));
 testRateLimiterSQLite("better-sqlite3", () => new betterSQLite3(":memory:"));
 
 // Run test with knex using better-sqlite3 in-memory database
-testRateLimiterSQLite("knex", () =>
-  knex({
-    client: "better-sqlite3",
-    connection: { filename: ":memory:" },
-  })
+testRateLimiterSQLite(
+  "knex",
+  () =>
+    knex({
+      client: "better-sqlite3",
+      connection: { filename: ":memory:" },
+      useNullAsDefault: true,
+    }),
+  "knex(better-sqlite3)"
 );
 
 // Run test with knex using sqlite3 in-memory database
-testRateLimiterSQLite("knex", () =>
-  knex({
-    client: "sqlite3",
-    connection: { filename: ":memory:" },
-  })
+testRateLimiterSQLite(
+  "knex",
+  () =>
+    knex({
+      client: "sqlite3",
+      connection: { filename: ":memory:" },
+      useNullAsDefault: true,
+    }),
+  "knex(sqlite3)"
 );


### PR DESCRIPTION
This fixes an issue where an unused Knex connection remained open, causing pool connection problems. Additionally, this adds functions to run tests against Knex.