### PR TITLE
Adapt `_isRedisReady` Check for v4/v5 `node-redis` Clients

### DIFF
--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -43,10 +43,11 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
    * Prevent actual redis call if redis connection is not ready
    * Because of different connection state checks for ioredis and node-redis, only this clients would be actually checked.
    * For any other clients all the requests would be passed directly to redis client
+   * @param {String} rlKey
    * @return {boolean}
    * @private
    */
-  _isRedisReady() {
+  _isRedisReady(rlKey) {
     if (!this._rejectIfRedisNotReady) {
       return true;
     }
@@ -54,8 +55,16 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
     if (this.client.status && this.client.status !== 'ready') {
       return false;
     }
-    // node-redis client
+    // node-redis v3 client
     if (typeof this.client.isReady === 'function' && !this.client.isReady()) {
+      return false;
+    }
+    // node-redis v4 and above (non-cluster) client
+    if (this.client.isReady && this.client.isReady !== true) {
+      return false;
+    }
+    // node-redis v4 and above cluster client
+    if (this.client.isOpen !== true || (this.client._slots && typeof this.client._slots.getClient === 'function' && this.client._slots.getClient(rlKey).isReady !== true)) {
       return false;
     }
     return true;
@@ -89,7 +98,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
       throw new Error("Consuming decimal number of points is not supported by this package");
     }
 
-    if (!this._isRedisReady()) {
+    if (!this._isRedisReady(rlKey)) {
       throw new Error('Redis connection is not ready');
     }
 
@@ -150,7 +159,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   }
 
   async _get(rlKey) {
-    if (!this._isRedisReady()) {
+    if (!this._isRedisReady(rlKey)) {
       throw new Error('Redis connection is not ready');
     }
     if(!this.useRedisPackage && !this.useRedis3AndLowerPackage){

--- a/lib/RateLimiterRedis.js
+++ b/lib/RateLimiterRedis.js
@@ -44,10 +44,11 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
    * Because of different connection state checks for ioredis and node-redis, only this clients would be actually checked.
    * For any other clients all the requests would be passed directly to redis client
    * @param {String} rlKey
+   * @param {Boolean} isReadonly
    * @return {boolean}
    * @private
    */
-  _isRedisReady(rlKey) {
+  _isRedisReady(rlKey, isReadonly) {
     if (!this._rejectIfRedisNotReady) {
       return true;
     }
@@ -64,7 +65,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
       return false;
     }
     // node-redis v4 and above cluster client
-    if (this.client.isOpen !== true || (this.client._slots && typeof this.client._slots.getClient === 'function' && this.client._slots.getClient(rlKey).isReady !== true)) {
+    if (this.client.isOpen !== true || (this.client._slots && typeof this.client._slots.getClient === 'function' && this.client._slots.getClient(rlKey, isReadonly).isReady !== true)) {
       return false;
     }
     return true;
@@ -98,7 +99,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
       throw new Error("Consuming decimal number of points is not supported by this package");
     }
 
-    if (!this._isRedisReady(rlKey)) {
+    if (!this._isRedisReady(rlKey, false)) {
       throw new Error('Redis connection is not ready');
     }
 
@@ -159,7 +160,7 @@ class RateLimiterRedis extends RateLimiterStoreAbstract {
   }
 
   async _get(rlKey) {
-    if (!this._isRedisReady(rlKey)) {
+    if (!this._isRedisReady(rlKey, true)) {
       throw new Error('Redis connection is not ready');
     }
     if(!this.useRedisPackage && !this.useRedis3AndLowerPackage){


### PR DESCRIPTION
Fixes https://github.com/animir/node-rate-limiter-flexible/issues/329

This PR updates the `_isRedisReady` fucntion for new v4/v5 `node-redis` clients.
They do no longer have a `isReady()` function but a boolean property `isReady`:

```js
// isOpen will return False here as the client's socket is not open yet.
// isReady will return False here, client is not yet ready to use.
console.log(`client.isOpen: ${client.isOpen}, client.isReady: ${client.isReady}`);
```

This PR adds the following changes to the `_isRedisReady`

1. It adds an check for v4/v5 (non-cluster) node-redis clients by checking the boolean property `isReady`
2. It adds an check for v4/v5 cluster node-redis clients by getting the respective client for the key (distinguishing between read-only and writing nodes) and then checking the boolean property `isReady` on the correct client