### PR TITLE
RateLimiterQueue default params 

### DIFF
--- a/lib/RateLimiterQueue.js
+++ b/lib/RateLimiterQueue.js
@@ -4,10 +4,14 @@ const KEY_DEFAULT = 'limiter';
 
 module.exports = class RateLimiterQueue {
   constructor(limiterFlexible, opts = {}) {
-    const maxQueueSize = opts.maxQueueSize !== undefined ? opts.maxQueueSize : MAX_QUEUE_SIZE;
-    const key = opts.key !== undefined ? opts.key : KEY_DEFAULT;
+    const maxQueueSize =
+      opts.maxQueueSize !== undefined ? opts.maxQueueSize : MAX_QUEUE_SIZE;
     this._queueLimiters = {
-      KEY_DEFAULT: new RateLimiterQueueInternal(limiterFlexible, { ...opts, maxQueueSize, key })
+      KEY_DEFAULT: new RateLimiterQueueInternal(limiterFlexible, {
+        ...opts,
+        maxQueueSize,
+        key: KEY_DEFAULT
+      }),
     };
     this._limiterFlexible = limiterFlexible;
     this._maxQueueSize = maxQueueSize;

--- a/types.d.ts
+++ b/types.d.ts
@@ -408,7 +408,7 @@ export class RLWrapperTimeouts extends RateLimiterInsuredAbstract {
 }
 
 interface IRateLimiterQueueOpts {
-    maxQueueSize: number;
+    maxQueueSize?: number;
 }
 
 export class RateLimiterQueue {


### PR DESCRIPTION
# Issue: RateLimiterQueue maxQueueSize defaults to undefined when opts is passed without it

When creating a `RateLimiterQueue` with an options object like this `{}` then defaulting in the constructor doesn't work correctly  but d.ts types allowed it thus leading to the runtime errors like this one
```
CustomError: Number of requests reached it's maximum undefined
```


it happens because 0 < undefined evaluates to false

How to reproduce

```
const queue = new RateLimiterQueue(limiter, {});
queue.removeTokens(1); // immediately rejects even with empty queue
```

After Fix

 `new RateLimiterQueue(limiter)` -> uses default MAX_QUEUE_SIZE 
 `new RateLimiterQueue(limiter, { maxQueueSize: 100 })` -> uses 100 
 `new RateLimiterQueue(limiter, {})` -> No TypeScript Errors uses default MAX_QUEUE_SIZE 