### PR TITLE
fix(DynamoDB): return null for expired keys in get() method

### DIFF
--- a/lib/RateLimiterDynamo.js
+++ b/lib/RateLimiterDynamo.js
@@ -154,15 +154,23 @@ class RateLimiterDynamo extends RateLimiterStoreAbstract {
       };
       
       const data = await this.client.getItem(params);
-      if(data.Item) {
-        return new DynamoItem(
+      
+      if (!data.Item) {
+          return null;
+        }
+
+        const item = new DynamoItem(
           data.Item.key.S,
           Number(data.Item.points.N),
           Number(data.Item.expire.N)
         );
-      } else {
-        return null;
-      }
+
+        const dateNowSec = Date.now() / 1000;
+
+        if (item.expire !== -1 && item.expire <= dateNowSec) {
+          return null;
+        }
+        return item;
     }
 
     /**


### PR DESCRIPTION
## Description
Fixes #310 

The `get()` method in `RateLimiterDynamo` was returning expired items instead of `null`. DynamoDB's TTL cleanup can take up to 48 hours, so the library must validate expiration timestamps client-side.

## Problem
The `_get()` method checked if an item exists but never validated the `expire` timestamp, causing:
- Rate limits to persist beyond their intended duration

## Solution
Added expiration validation in `_get()`:
- Return `null` if `item.expire <= currentTime`
- Treat `-1` as never-expiring (unchanged)
