### PR TITLE
fix execEvenlyMinDelayMs not reflecting points/duration mutation

### DIFF
--- a/lib/RateLimiterAbstract.js
+++ b/lib/RateLimiterAbstract.js
@@ -69,12 +69,18 @@ module.exports = class RateLimiterAbstract {
 
   get execEvenlyMinDelayMs() {
     return this._execEvenlyMinDelayMs === undefined
-      ? Math.ceil(this.msDuration / this.points)
+      ? this._getExecEvenlyMinDelayMsDefault()
       : this._execEvenlyMinDelayMs;
   }
 
   set execEvenlyMinDelayMs(value) {
     this._execEvenlyMinDelayMs = value;
+  }
+
+  _getExecEvenlyMinDelayMsDefault() {
+    return this.points > 0
+      ? Math.ceil(this.msDuration / this.points)
+      : 0;
   }
 
   get keyPrefix() {

--- a/lib/RateLimiterAbstract.js
+++ b/lib/RateLimiterAbstract.js
@@ -68,11 +68,13 @@ module.exports = class RateLimiterAbstract {
   }
 
   get execEvenlyMinDelayMs() {
-    return this._execEvenlyMinDelayMs;
+    return this._execEvenlyMinDelayMs === undefined
+      ? Math.ceil(this.msDuration / this.points)
+      : this._execEvenlyMinDelayMs;
   }
 
   set execEvenlyMinDelayMs(value) {
-    this._execEvenlyMinDelayMs = typeof value === 'undefined' ? Math.ceil(this.msDuration / this.points) : value;
+    this._execEvenlyMinDelayMs = value;
   }
 
   get keyPrefix() {

--- a/lib/RateLimiterMemory.js
+++ b/lib/RateLimiterMemory.js
@@ -29,7 +29,7 @@ class RateLimiterMemory extends RateLimiterAbstract {
           res = this._memoryStorage.set(rlKey, res.consumedPoints, this.blockDuration);
         }
         reject(res);
-      } else if (this.execEvenly && res.msBeforeNext > 0 && !res.isFirstInDuration) {
+      } else if (this.execEvenly && this.points > 0 && res.msBeforeNext > 0 && !res.isFirstInDuration) {
         // Execute evenly
         let delay = Math.ceil(res.msBeforeNext / (res.remainingPoints + 2));
         if (delay < this.execEvenlyMinDelayMs) {

--- a/lib/RateLimiterStoreAbstract.js
+++ b/lib/RateLimiterStoreAbstract.js
@@ -79,7 +79,7 @@ module.exports = class RateLimiterStoreAbstract extends RateLimiterInsuredAbstra
         .catch((err) => {
           reject(err);
         });
-    } else if (this.execEvenly && res.msBeforeNext > 0 && !res.isFirstInDuration) {
+    } else if (this.execEvenly && this.points > 0 && res.msBeforeNext > 0 && !res.isFirstInDuration) {
       let delay = Math.ceil(res.msBeforeNext / (res.remainingPoints + 2));
       if (delay < this.execEvenlyMinDelayMs) {
         delay = res.consumedPoints * this.execEvenlyMinDelayMs;

--- a/test/RateLimiterAbstract.test.js
+++ b/test/RateLimiterAbstract.test.js
@@ -118,6 +118,43 @@ describe('RateLimiterAbstract', function () {
       rateLimiter.points = 100;
       expect(rateLimiter.execEvenlyMinDelayMs).to.equal(42);
     });
+
+    it('returns to derived value when explicit value is reset to undefined', () => {
+      const rateLimiter = new RateLimiterAbstract({
+        points: 10, duration: 1, execEvenlyMinDelayMs: 42,
+      });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(42);
+
+      rateLimiter.execEvenlyMinDelayMs = undefined;
+      rateLimiter.points = 20;
+      rateLimiter.duration = 2;
+
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(100);
+    });
+
+    it('returns zero when points is zero in auto mode', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: 0, duration: 5 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(0);
+    });
+
+    it('returns zero when points is negative in auto mode', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: -5, duration: 5 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(0);
+    });
+
+    it('returns zero after points is mutated to zero in auto mode', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: 10, duration: 1 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(100);
+
+      rateLimiter.points = 0;
+
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(0);
+    });
+
+    it('returns zero when duration is zero in auto mode', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: 10, duration: 0 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(0);
+    });
   });
 
   describe('parseKey', () => {

--- a/test/RateLimiterAbstract.test.js
+++ b/test/RateLimiterAbstract.test.js
@@ -96,6 +96,30 @@ describe('RateLimiterAbstract', function () {
     }).to.throw('duration must be set and must be a finite, non-negative number');
   });
 
+  describe('execEvenlyMinDelayMs', () => {
+    it('re-derives from points after points is mutated', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: 1, duration: 1 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(1000);
+      rateLimiter.points = 10;
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(100);
+    });
+
+    it('re-derives from duration after duration is mutated', () => {
+      const rateLimiter = new RateLimiterAbstract({ points: 10, duration: 1 });
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(100);
+      rateLimiter.duration = 5;
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(500);
+    });
+
+    it('keeps explicit value after points is mutated', () => {
+      const rateLimiter = new RateLimiterAbstract({
+        points: 10, duration: 1, execEvenlyMinDelayMs: 42,
+      });
+      rateLimiter.points = 100;
+      expect(rateLimiter.execEvenlyMinDelayMs).to.equal(42);
+    });
+  });
+
   describe('parseKey', () => {
     it('removes default keyPrefix and colon from key', () => {
       const rateLimiter = new RateLimiterAbstract({ points: 4, duration: 1 });

--- a/test/RateLimiterMemory.test.js
+++ b/test/RateLimiterMemory.test.js
@@ -120,6 +120,61 @@ describe('RateLimiterMemory with fixed window', function RateLimiterMemoryTest()
       });
   });
 
+  it('uses updated derived minimum delay after points is mutated', (done) => {
+    const testKey = 'consumeEvenlyAfterPointsMutation';
+    const rateLimiterMemory = new RateLimiterMemory({
+      points: 1, duration: 1, execEvenly: true,
+    });
+
+    rateLimiterMemory.points = 100;
+
+    rateLimiterMemory.consume(testKey)
+      .then(() => {
+        const timeFirstConsume = Date.now();
+        rateLimiterMemory.consume(testKey)
+          .then(() => {
+            const diff = Date.now() - timeFirstConsume;
+
+            expect(diff).to.be.greaterThan(5);
+            expect(diff).to.be.lessThan(250);
+            done();
+          })
+          .catch((err) => {
+            done(err);
+          });
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
+  it('keeps execEvenly immediate when points is mutated to zero', (done) => {
+    const testKey = 'consumeEvenlyAfterZeroPointsMutation';
+    const rateLimiterMemory = new RateLimiterMemory({
+      points: 10, duration: 1, execEvenly: true,
+    });
+
+    rateLimiterMemory.points = 0;
+
+    rateLimiterMemory.consume(testKey, 0)
+      .then(() => {
+        const timeFirstConsume = Date.now();
+        rateLimiterMemory.consume(testKey, 0)
+          .then(() => {
+            const diff = Date.now() - timeFirstConsume;
+
+            expect(diff).to.be.lessThan(50);
+            done();
+          })
+          .catch((err) => {
+            done(err);
+          });
+      })
+      .catch((err) => {
+        done(err);
+      });
+  });
+
   it('makes penalty', (done) => {
     const testKey = 'penalty1';
     const rateLimiterMemory = new RateLimiterMemory({ points: 3, duration: 5 });


### PR DESCRIPTION
The setter evaluated the default at first assignment and cached it, so
runtime updates to points or duration left the spacing computed from
construction-time values. The docs state that options can be changed at
runtime; this brings execEvenlyMinDelayMs in line with that contract.

Now: if execEvenlyMinDelayMs was never explicitly set, the getter
derives it from the current msDuration/points on each read. Explicit
values are still honoured.
