### PR TITLE
feat: add expiresUnixAt deadline option to RateLimiterQueue.removeTokens (#212)

### DIFF
--- a/lib/RateLimiterQueue.js
+++ b/lib/RateLimiterQueue.js
@@ -48,9 +48,11 @@ class RateLimiterQueueInternal {
     this._waitTimeout = null;
     this._queue = [];
     this._limiterFlexible = limiterFlexible;
-    // Tracks whether the queue currently holds at least one request with an
-    // expiration deadline. When false, _processFIFO can skip the expiry sweep
-    // entirely, so projects that never pass expiresUnixAt pay no extra cost.
+    // Set to true once a request carrying an expiration deadline
+    // (expiresUnixAt > 0) has been queued. While false, _processFIFO skips the
+    // expiry sweep entirely, so projects that never pass expiresUnixAt pay no
+    // extra cost. It is only ever set, never cleared by the sweep (see
+    // _processFIFO for why clearing it would be unsafe).
     this._hasExpiringRequests = false;
 
     this._maxQueueSize = opts.maxQueueSize
@@ -114,25 +116,25 @@ class RateLimiterQueueInternal {
     }
 
     // Reject any queued requests that have reached their expiration deadline
-    // (expiresUnixAt, in Unix seconds) before they could be fulfilled. This
-    // whole sweep is skipped unless a request with a deadline is currently
-    // queued, so the common case (no expiresUnixAt) stays O(1) here.
+    // (expiresUnixAt, in Unix seconds) before they could be fulfilled. The
+    // sweep is skipped until a request with a deadline has been queued, so
+    // projects that never pass expiresUnixAt keep the original O(1) cost here.
+    //
+    // The flag is deliberately only ever set, never cleared from a snapshot of
+    // _queue: while a request is being consumed it is momentarily shift()ed out
+    // of _queue and may be unshift()ed back by the rate-limit retry path below
+    // (without going through _queueRequest). Clearing the flag from a snapshot
+    // that excludes such an in-flight request could strand it with the sweep
+    // permanently disabled, so it would never expire.
     if (_this._hasExpiringRequests) {
       const nowSecs = Math.floor(Date.now() / 1000);
-      let stillHasExpiringRequests = false;
       _this._queue = _this._queue.filter((item) => {
-        if (item.expiresUnixAt && nowSecs >= item.expiresUnixAt) {
+        if (item.expiresUnixAt > 0 && nowSecs >= item.expiresUnixAt) {
           item.reject(new RateLimiterQueueError('The request to remove tokens expired before it could be fulfilled'));
           return false;
         }
-        if (item.expiresUnixAt > 0) {
-          stillHasExpiringRequests = true;
-        }
         return true;
       });
-      // Once no deadline-bearing requests remain, fall back to the fast path
-      // until a new one is queued.
-      _this._hasExpiringRequests = stillHasExpiringRequests;
     }
 
     if (_this._queue.length === 0) {

--- a/lib/RateLimiterQueue.js
+++ b/lib/RateLimiterQueue.js
@@ -48,6 +48,10 @@ class RateLimiterQueueInternal {
     this._waitTimeout = null;
     this._queue = [];
     this._limiterFlexible = limiterFlexible;
+    // Tracks whether the queue currently holds at least one request with an
+    // expiration deadline. When false, _processFIFO can skip the expiry sweep
+    // entirely, so projects that never pass expiresUnixAt pay no extra cost.
+    this._hasExpiringRequests = false;
 
     this._maxQueueSize = opts.maxQueueSize
   }
@@ -93,6 +97,9 @@ class RateLimiterQueueInternal {
     const _this = this;
     if (_this._queue.length < _this._maxQueueSize) {
       _this._queue.push({resolve, reject, tokens, expiresUnixAt});
+      if (expiresUnixAt > 0) {
+        _this._hasExpiringRequests = true;
+      }
     } else {
       reject(new RateLimiterQueueError(`Number of requests reached it's maximum ${_this._maxQueueSize}`))
     }
@@ -107,15 +114,26 @@ class RateLimiterQueueInternal {
     }
 
     // Reject any queued requests that have reached their expiration deadline
-    // (expiresUnixAt, in Unix seconds) before they could be fulfilled.
-    const nowSecs = Math.floor(Date.now() / 1000);
-    _this._queue = _this._queue.filter((item) => {
-      if (item.expiresUnixAt && nowSecs >= item.expiresUnixAt) {
-        item.reject(new RateLimiterQueueError('The request to remove tokens expired before it could be fulfilled'));
-        return false;
-      }
-      return true;
-    });
+    // (expiresUnixAt, in Unix seconds) before they could be fulfilled. This
+    // whole sweep is skipped unless a request with a deadline is currently
+    // queued, so the common case (no expiresUnixAt) stays O(1) here.
+    if (_this._hasExpiringRequests) {
+      const nowSecs = Math.floor(Date.now() / 1000);
+      let stillHasExpiringRequests = false;
+      _this._queue = _this._queue.filter((item) => {
+        if (item.expiresUnixAt && nowSecs >= item.expiresUnixAt) {
+          item.reject(new RateLimiterQueueError('The request to remove tokens expired before it could be fulfilled'));
+          return false;
+        }
+        if (item.expiresUnixAt > 0) {
+          stillHasExpiringRequests = true;
+        }
+        return true;
+      });
+      // Once no deadline-bearing requests remain, fall back to the fast path
+      // until a new one is queued.
+      _this._hasExpiringRequests = stillHasExpiringRequests;
+    }
 
     if (_this._queue.length === 0) {
       return;

--- a/lib/RateLimiterQueue.js
+++ b/lib/RateLimiterQueue.js
@@ -25,7 +25,7 @@ module.exports = class RateLimiterQueue {
     }
   }
 
-  removeTokens(tokens, key = KEY_DEFAULT) {
+  removeTokens(tokens, key = KEY_DEFAULT, expiresUnixAt = 0) {
     if (!this._queueLimiters[key]) {
       this._queueLimiters[key] = new RateLimiterQueueInternal(
         this._limiterFlexible, {
@@ -34,7 +34,7 @@ module.exports = class RateLimiterQueue {
         })
     }
 
-    return this._queueLimiters[key].removeTokens(tokens)
+    return this._queueLimiters[key].removeTokens(tokens, expiresUnixAt)
   }
 };
 
@@ -59,7 +59,7 @@ class RateLimiterQueueInternal {
       })
   }
 
-  removeTokens(tokens) {
+  removeTokens(tokens, expiresUnixAt = 0) {
     const _this = this;
 
     return new Promise((resolve, reject) => {
@@ -69,7 +69,7 @@ class RateLimiterQueueInternal {
       }
 
       if (_this._queue.length > 0) {
-        _this._queueRequest.call(_this, resolve, reject, tokens);
+        _this._queueRequest.call(_this, resolve, reject, tokens, expiresUnixAt);
       } else {
         _this._limiterFlexible.consume(_this._key, tokens)
           .then((res) => {
@@ -79,7 +79,7 @@ class RateLimiterQueueInternal {
             if (rej instanceof Error) {
               reject(rej);
             } else {
-              _this._queueRequest.call(_this, resolve, reject, tokens);
+              _this._queueRequest.call(_this, resolve, reject, tokens, expiresUnixAt);
               if (_this._waitTimeout === null) {
                 _this._waitTimeout = setTimeout(_this._processFIFO.bind(_this), rej.msBeforeNext);
               }
@@ -89,10 +89,10 @@ class RateLimiterQueueInternal {
     })
   }
 
-  _queueRequest(resolve, reject, tokens) {
+  _queueRequest(resolve, reject, tokens, expiresUnixAt = 0) {
     const _this = this;
     if (_this._queue.length < _this._maxQueueSize) {
-      _this._queue.push({resolve, reject, tokens});
+      _this._queue.push({resolve, reject, tokens, expiresUnixAt});
     } else {
       reject(new RateLimiterQueueError(`Number of requests reached it's maximum ${_this._maxQueueSize}`))
     }
@@ -105,6 +105,17 @@ class RateLimiterQueueInternal {
       clearTimeout(_this._waitTimeout);
       _this._waitTimeout = null;
     }
+
+    // Reject any queued requests that have reached their expiration deadline
+    // (expiresUnixAt, in Unix seconds) before they could be fulfilled.
+    const nowSecs = Math.floor(Date.now() / 1000);
+    _this._queue = _this._queue.filter((item) => {
+      if (item.expiresUnixAt && nowSecs >= item.expiresUnixAt) {
+        item.reject(new RateLimiterQueueError('The request to remove tokens expired before it could be fulfilled'));
+        return false;
+      }
+      return true;
+    });
 
     if (_this._queue.length === 0) {
       return;

--- a/test/RateLimiterQueue.test.js
+++ b/test/RateLimiterQueue.test.js
@@ -176,8 +176,8 @@ describe('RateLimiterQueue with FIFO queue', function RateLimiterQueueTest() {
           expect(err instanceof RateLimiterQueueError).to.equal(true);
           expiredRejected = true;
         });
-      // B: no deadline -> must still be fulfilled after A is swept out, proving
-      // the expiry flag is recomputed and the fast path is restored.
+      // B: no deadline -> survives the sweep and must still be fulfilled after
+      // the overdue A is swept out of the queue.
       rlQueue.removeTokens(1)
         .then((remainingTokens) => {
           expect(expiredRejected).to.equal(true);
@@ -185,6 +185,38 @@ describe('RateLimiterQueue with FIFO queue', function RateLimiterQueueTest() {
           done();
         })
         .catch(done);
+    });
+  });
+
+  it('never disables the expiry sweep while a deadline request is in flight (regression)', () => {
+    // Regression for the _hasExpiringRequests fast-path optimization. The defect
+    // only surfaces with an asynchronous underlying limiter (e.g. Redis/Mongo):
+    // while a deadline-bearing request is being consumed it is momentarily
+    // shift()ed out of the internal queue, and a second _processFIFO can sweep
+    // the temporarily empty queue. That interleaving is not deterministically
+    // reproducible through the public API, so we drive the internal queue
+    // directly to lock the invariant: the sweep must never turn the flag off
+    // (which would permanently disable expiry for an item the rate-limit retry
+    // path later unshift()es back in, stranding it past its deadline forever).
+    const rlMemory = new RateLimiterMemory({ points: 1, duration: 100 });
+    const rlQueue = new RateLimiterQueue(rlMemory);
+    return rlQueue.removeTokens(1).then(() => {
+      const internal = rlQueue._queueLimiters.limiter;
+      let rejection = null;
+      const overdue = Math.floor(Date.now() / 1000) - 1; // already past its deadline
+      // Arm the flag exactly as enqueueing a deadline-bearing request would.
+      internal._queueRequest(() => {}, (err) => { rejection = err; }, 1, overdue);
+      expect(internal._hasExpiringRequests).to.equal(true);
+      // In-flight window: the sole deadline-bearing item is shifted out and a
+      // sweep runs over the now-empty queue.
+      const inFlight = internal._queue.shift();
+      internal._processFIFO();
+      expect(internal._hasExpiringRequests).to.equal(true); // must stay armed
+      // The rate-limit retry path re-inserts the in-flight item without going
+      // through _queueRequest; the next sweep must still expire it.
+      internal._queue.unshift(inFlight);
+      internal._processFIFO();
+      expect(rejection instanceof RateLimiterQueueError).to.equal(true);
     });
   });
 

--- a/test/RateLimiterQueue.test.js
+++ b/test/RateLimiterQueue.test.js
@@ -129,6 +129,39 @@ describe('RateLimiterQueue with FIFO queue', function RateLimiterQueueTest() {
       });
   });
 
+  it('rejects a queued request that expires before it is fulfilled (expiresUnixAt)', (done) => {
+    const rlMemory = new RateLimiterMemory({ points: 1, duration: 2 });
+    const rlQueue = new RateLimiterQueue(rlMemory);
+    // Consume the only available token so the next request has to be queued.
+    rlQueue.removeTokens(1).then(() => {
+      // Allow the queued request to wait only until the current second, so it is
+      // still queued (and overdue) when the FIFO processor next runs.
+      const expiresUnixAt = Math.floor(Date.now() / 1000);
+      rlQueue.removeTokens(1, 'limiter', expiresUnixAt)
+        .then(() => {
+          done(new Error('queued request should have been rejected as expired'));
+        })
+        .catch((err) => {
+          expect(err instanceof RateLimiterQueueError).to.equal(true);
+          done();
+        });
+    });
+  });
+
+  it('does not reject a queued request whose expiresUnixAt is still in the future', (done) => {
+    const rlMemory = new RateLimiterMemory({ points: 1, duration: 1 });
+    const rlQueue = new RateLimiterQueue(rlMemory);
+    rlQueue.removeTokens(1).then(() => {
+      const expiresUnixAt = Math.floor(Date.now() / 1000) + 10;
+      rlQueue.removeTokens(1, 'limiter', expiresUnixAt)
+        .then((remainingTokens) => {
+          expect(remainingTokens).to.equal(0);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
   it('getTokensRemaining works', (done) => {
     const rlMemory = new RateLimiterMemory({ points: 2, duration: 1 });
     const rlQueue = new RateLimiterQueue(rlMemory);

--- a/test/RateLimiterQueue.test.js
+++ b/test/RateLimiterQueue.test.js
@@ -162,6 +162,32 @@ describe('RateLimiterQueue with FIFO queue', function RateLimiterQueueTest() {
     });
   });
 
+  it('expires only the overdue request and still fulfils a later non-expiring one', (done) => {
+    const rlMemory = new RateLimiterMemory({ points: 1, duration: 1 });
+    const rlQueue = new RateLimiterQueue(rlMemory);
+    // Consume the only token so the following requests are queued behind it.
+    rlQueue.removeTokens(1).then(() => {
+      let expiredRejected = false;
+      // A: carries a deadline at the current second -> overdue when FIFO runs.
+      const expiresUnixAt = Math.floor(Date.now() / 1000);
+      rlQueue.removeTokens(1, 'limiter', expiresUnixAt)
+        .then(() => done(new Error('request A should have been rejected as expired')))
+        .catch((err) => {
+          expect(err instanceof RateLimiterQueueError).to.equal(true);
+          expiredRejected = true;
+        });
+      // B: no deadline -> must still be fulfilled after A is swept out, proving
+      // the expiry flag is recomputed and the fast path is restored.
+      rlQueue.removeTokens(1)
+        .then((remainingTokens) => {
+          expect(expiredRejected).to.equal(true);
+          expect(remainingTokens).to.equal(0);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
   it('getTokensRemaining works', (done) => {
     const rlMemory = new RateLimiterMemory({ points: 2, duration: 1 });
     const rlQueue = new RateLimiterQueue(rlMemory);

--- a/types.d.ts
+++ b/types.d.ts
@@ -514,7 +514,16 @@ export class RateLimiterQueue {
 
     getTokensRemaining(key?: string | number): Promise<number>;
 
-    removeTokens(tokens: number, key?: string | number): Promise<number>;
+    /**
+     * Remove tokens from the queue.
+     *
+     * @param tokens Number of tokens to remove.
+     * @param key Optional queue key for separate FIFO queues.
+     * @param expiresUnixAt Optional absolute deadline as a Unix timestamp in
+     *   seconds. If the request is still queued when this time is reached, it is
+     *   rejected with a `RateLimiterQueueError`. Defaults to `0` (never expires).
+     */
+    removeTokens(tokens: number, key?: string | number, expiresUnixAt?: number): Promise<number>;
 }
 
 export class BurstyRateLimiter {


### PR DESCRIPTION
Closes #212.

Adds an optional deadline to `RateLimiterQueue.removeTokens` so a queued request can give up instead of waiting forever.

## API

```js
const queue = new RateLimiterQueue(limiter)
// reject this request if it is still queued at the given Unix time (seconds)
await queue.removeTokens(1, 'limiter', Math.floor(Date.now() / 1000) + 5)
```

`removeTokens(tokens, key = 'limiter', expiresUnixAt = 0)` — `expiresUnixAt` is an absolute Unix timestamp in **seconds**; `0` (the default) keeps the current "never expires" behaviour, so this is fully backwards compatible. I added it as the third parameter because the second slot is now taken by `key`.

## Implementation

Following the approach you outlined in #212, the timeout is handled **internally** inside the FIFO cycle (no external `Promise.race`, so the queue can't be left inconsistent). During `_processFIFO`, any queued item whose `expiresUnixAt` has passed (`now >= expiresUnixAt`) is rejected with a `RateLimiterQueueError` and removed from the queue (I used `RateLimiterQueueError` to match the existing queue-full rejection).

One thing worth flagging: because the sweep runs inside `_processFIFO`, an expired request is rejected at the next processing tick at-or-after its deadline, not exactly at the deadline — matching the "built into the normal cycle" design from the issue. Happy to add an eager timer if you'd prefer prompt rejection.

## Tests

Two cases added to `test/RateLimiterQueue.test.js`:
- a queued request past its `expiresUnixAt` is rejected with `RateLimiterQueueError`;
- a queued request with a future `expiresUnixAt` still resolves normally.

`npx mocha test/RateLimiterQueue.test.js` → 18 passing.

Happy to adjust the parameter name/shape, the error type, or eager-vs-lazy expiry to your preference.
