### PR TITLE
fix(postgres): don't name the one-off create-table prepared statement (#196)

### DIFF
--- a/lib/RateLimiterPostgres.js
+++ b/lib/RateLimiterPostgres.js
@@ -262,7 +262,13 @@ class RateLimiterPostgres extends RateLimiterStoreAbstract {
 
   _query(q) {
     const prefix = this.tableName.toLowerCase();
-    const queryObj = { name: `${prefix}:${q.name}`, text: q.text, values: q.values };
+    const queryObj = { text: q.text, values: q.values };
+    // Only name the prepared statement when a name is provided. The one-off
+    // create-table query passes no name, and naming it `${prefix}:undefined`
+    // pollutes the prepared-statement cache (see #196).
+    if (q.name) {
+      queryObj.name = `${prefix}:${q.name}`;
+    }
     return new Promise((resolve, reject) => {
       this._getConnection()
         .then((conn) => {

--- a/test/RateLimiterPostgres.test.js
+++ b/test/RateLimiterPostgres.test.js
@@ -60,6 +60,37 @@ describe('RateLimiterPostgres with fixed window', function RateLimiterPostgresTe
     });
   });
 
+  it('runs the create-table query without a named prepared statement (#196)', (done) => {
+    // The create-table query carries no `name` and runs once, so it must not be
+    // sent as a named prepared statement (previously the name became
+    // `<prefix>:undefined`). Named queries must still keep their name.
+    const rateLimiter = new RateLimiterPostgres({
+      storeClient: pgClient, storeType: 'client', points: 2, duration: 5,
+    }, () => {
+      try {
+        const createTableQuery = pgClientStub.getCall(0).args[0];
+        expect(createTableQuery.text).to.match(/CREATE TABLE/i);
+        expect('name' in createTableQuery).to.equal(false);
+      } catch (err) {
+        done(err);
+        return;
+      }
+
+      pgClientStub.restore();
+      pgClientStub = sinon.stub(pgClient, 'query').resolves({
+        rows: [{ points: 1, expire: 5000 }],
+      });
+      rateLimiter.consume('test196')
+        .then(() => {
+          const namedQuery = pgClientStub.getCall(0).args[0];
+          expect(namedQuery.name).to.be.a('string');
+          expect(namedQuery.name).to.match(/rlflx-upsert$/);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
   it('consume 1 point', (done) => {
     const testKey = 'consume1';
 


### PR DESCRIPTION
Fixes #196.

`_query()` built the prepared-statement name for **every** query as `${prefix}:${q.name}`. The one-off create-table query passes no `name`, so it was registered as the named prepared statement `${prefix}:undefined`.

This only sets a statement `name` when one is provided, so the create-table query runs as a simple (unnamed) query, while the named queries (`upsert` / `get` / `delete` / `clear-expired`) are unchanged.

Added a unit test (using the existing sinon-stubbed client — no database needed) asserting the create-table query carries no `name`, and that a named query still does.